### PR TITLE
Observer auto-task detection

### DIFF
--- a/src/commands/observe.ts
+++ b/src/commands/observe.ts
@@ -14,6 +14,7 @@ export interface ObserveCommandOptions {
   threshold?: number;
   reflectThreshold?: number;
   model?: string;
+  extractTasks?: boolean;
   compress?: string;
   daemon?: boolean;
   vaultPath?: string;
@@ -50,6 +51,9 @@ function buildDaemonArgs(options: ObserveCommandOptions): string[] {
   }
   if (options.model) {
     args.push('--model', options.model);
+  }
+  if (options.extractTasks === false) {
+    args.push('--no-extract-tasks');
   }
   if (options.vaultPath) {
     args.push('--vault', options.vaultPath);
@@ -131,7 +135,8 @@ export async function observeCommand(options: ObserveCommandOptions): Promise<vo
       dryRun: options.dryRun,
       threshold: options.threshold,
       reflectThreshold: options.reflectThreshold,
-      model: options.model
+      model: options.model,
+      extractTasks: options.extractTasks
     });
 
     if (result.candidateSessions === 0) {
@@ -160,7 +165,8 @@ export async function observeCommand(options: ObserveCommandOptions): Promise<vo
   const observer = new Observer(vaultPath, {
     tokenThreshold: options.threshold,
     reflectThreshold: options.reflectThreshold,
-    model: options.model
+    model: options.model,
+    extractTasks: options.extractTasks
   });
 
   if (options.compress) {
@@ -212,6 +218,8 @@ export function registerObserveCommand(program: Command): void {
     .option('--threshold <n>', 'Compression token threshold', '30000')
     .option('--reflect-threshold <n>', 'Reflection token threshold', '40000')
     .option('--model <model>', 'LLM model override')
+    .option('--extract-tasks', 'Extract task-like observations into backlog', true)
+    .option('--no-extract-tasks', 'Disable task extraction from observations')
     .option('--compress <file>', 'One-shot compression for a conversation file')
     .option('--daemon', 'Run in detached background mode')
     .option('-v, --vault <path>', 'Vault path')
@@ -225,6 +233,7 @@ export function registerObserveCommand(program: Command): void {
       threshold: string;
       reflectThreshold: string;
       model?: string;
+      extractTasks?: boolean;
       compress?: string;
       daemon?: boolean;
       vault?: string;
@@ -239,6 +248,7 @@ export function registerObserveCommand(program: Command): void {
         threshold: parsePositiveInteger(rawOptions.threshold, 'threshold'),
         reflectThreshold: parsePositiveInteger(rawOptions.reflectThreshold, 'reflect-threshold'),
         model: rawOptions.model,
+        extractTasks: rawOptions.extractTasks,
         compress: rawOptions.compress,
         daemon: rawOptions.daemon,
         vaultPath: rawOptions.vault

--- a/src/lib/observation-format.ts
+++ b/src/lib/observation-format.ts
@@ -3,6 +3,9 @@ export const OBSERVATION_TYPES = [
   'preference',
   'fact',
   'commitment',
+  'task',
+  'todo',
+  'commitment-unresolved',
   'milestone',
   'lesson',
   'relationship',
@@ -37,12 +40,16 @@ export const IMPORTANCE_THRESHOLDS: ImportanceThresholds = {
 
 export const DATE_HEADING_RE = /^##\s+(\d{4}-\d{2}-\d{2})\s*$/;
 const SCORED_LINE_RE =
-  /^(?:-\s*)?\[(decision|preference|fact|commitment|milestone|lesson|relationship|project)\|c=(0(?:\.\d+)?|1(?:\.0+)?)\|i=(0(?:\.\d+)?|1(?:\.0+)?)\]\s+(.+)$/i;
+  /^(?:-\s*)?\[(decision|preference|fact|commitment|task|todo|commitment-unresolved|milestone|lesson|relationship|project)\|c=(0(?:\.\d+)?|1(?:\.0+)?)\|i=(0(?:\.\d+)?|1(?:\.0+)?)\]\s+(.+)$/i;
 const EMOJI_LINE_RE = /^(?:-\s*)?(🔴|🟡|🟢)\s+(\d{2}:\d{2})?\s*(.+)$/u;
 
 const DECISION_RE = /\b(decis(?:ion|ions)?|decid(?:e|ed|ing)|chose|selected|opted|went with|picked)\b/i;
 const PREFERENCE_RE = /\b(prefer(?:ence|s|red)?|likes?|dislikes?|default to|always use|never use)\b/i;
 const COMMITMENT_RE = /\b(commit(?:ment|ted)?|promised|deadline|due|scheduled|will deliver|agreed to)\b/i;
+const TODO_RE = /(?:\btodo:\s*|\bwe need to\b|\bdon't forget(?: to)?\b|\bremember to\b|\bmake sure to\b)/i;
+const COMMITMENT_TASK_RE = /\b(?:i'?ll|i will|let me|(?:i'?m\s+)?going to|plan to|should)\b/i;
+const UNRESOLVED_RE = /\b(?:need to figure out|tbd|to be determined)\b/i;
+const DEADLINE_RE = /\b(?:by\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|tomorrow)|before\s+the\s+\w+|deadline is)\b/i;
 const MILESTONE_RE = /\b(released?|shipped|launched|merged|published|milestone|v\d+\.\d+)\b/i;
 const LESSON_RE = /\b(learn(?:ed|ing|t)|lesson|insight|realized|discovered|never again)\b/i;
 const RELATIONSHIP_RE = /\b(talked to|met with|spoke with|asked|client|partner|teammate|colleague)\b/i;
@@ -69,6 +76,9 @@ export function confidenceFromLegacyPriority(priority: LegacyObservationPriority
 
 export function inferObservationType(content: string): ObservationType {
   if (DECISION_RE.test(content)) return 'decision';
+  if (UNRESOLVED_RE.test(content)) return 'commitment-unresolved';
+  if (TODO_RE.test(content)) return 'todo';
+  if (COMMITMENT_TASK_RE.test(content) || DEADLINE_RE.test(content)) return 'task';
   if (COMMITMENT_RE.test(content)) return 'commitment';
   if (MILESTONE_RE.test(content)) return 'milestone';
   if (PREFERENCE_RE.test(content)) return 'preference';

--- a/src/lib/task-utils.ts
+++ b/src/lib/task-utils.ts
@@ -14,6 +14,7 @@ export type TaskPriority = 'critical' | 'high' | 'medium' | 'low';
 // Task frontmatter interface
 export interface TaskFrontmatter {
   status: TaskStatus;
+  source?: string;
   owner?: string;
   project?: string;
   priority?: TaskPriority;
@@ -39,6 +40,7 @@ export interface BacklogFrontmatter {
   source?: string;
   project?: string;
   created: string;
+  lastSeen?: string;
   tags?: string[];
 }
 
@@ -280,6 +282,7 @@ export function createTask(
   vaultPath: string,
   title: string,
   options: {
+    source?: string;
     owner?: string;
     project?: string;
     priority?: TaskPriority;
@@ -303,6 +306,7 @@ export function createTask(
     updated: now
   };
 
+  if (options.source) frontmatter.source = options.source;
   if (options.owner) frontmatter.owner = options.owner;
   if (options.project) frontmatter.project = options.project;
   if (options.priority) frontmatter.priority = options.priority;
@@ -467,6 +471,42 @@ export function createBacklogItem(
     content,
     frontmatter,
     path: backlogPath
+  };
+}
+
+/**
+ * Update an existing backlog item frontmatter.
+ */
+export function updateBacklogItem(
+  vaultPath: string,
+  slug: string,
+  updates: {
+    source?: string;
+    project?: string;
+    tags?: string[];
+    lastSeen?: string;
+  }
+): BacklogItem {
+  const backlogItem = readBacklogItem(vaultPath, slug);
+  if (!backlogItem) {
+    throw new Error(`Backlog item not found: ${slug}`);
+  }
+
+  const newFrontmatter: BacklogFrontmatter = {
+    ...backlogItem.frontmatter
+  };
+
+  if (updates.source !== undefined) newFrontmatter.source = updates.source;
+  if (updates.project !== undefined) newFrontmatter.project = updates.project;
+  if (updates.tags !== undefined) newFrontmatter.tags = updates.tags;
+  if (updates.lastSeen !== undefined) newFrontmatter.lastSeen = updates.lastSeen;
+
+  const fileContent = matter.stringify(backlogItem.content, newFrontmatter);
+  fs.writeFileSync(backlogItem.path, fileContent);
+
+  return {
+    ...backlogItem,
+    frontmatter: newFrontmatter
   };
 }
 

--- a/src/observer/active-session-observer.ts
+++ b/src/observer/active-session-observer.ts
@@ -31,6 +31,7 @@ export interface ActiveObserveOptions {
   threshold?: number;
   reflectThreshold?: number;
   model?: string;
+  extractTasks?: boolean;
 }
 
 export interface ActiveObservationCandidate {
@@ -492,7 +493,8 @@ export async function observeActiveSessions(
   const observer = observerFactory(vaultPath, {
     tokenThreshold: options.threshold,
     reflectThreshold: options.reflectThreshold,
-    model: options.model
+    model: options.model,
+    extractTasks: options.extractTasks
   });
 
   let observedSessions = 0;

--- a/src/observer/compressor.test.ts
+++ b/src/observer/compressor.test.ts
@@ -94,4 +94,93 @@ describe('Compressor', () => {
     expect(output).toMatch(/\[[a-z]+\|c=\d\.\d{2}\|i=0\.(4\d|5\d|6\d|7\d)\].*Routine deadline next sprint for docs refresh/);
     expect(output).toMatch(/\[[a-z]+\|c=\d\.\d{2}\|i=0\.(8\d|9\d)\].*Release deadline is 2026-02-28 for migration cutover/);
   });
+
+  it('detects explicit TODO variants as todo observations', async () => {
+    process.env.ANTHROPIC_API_KEY = '';
+    process.env.OPENAI_API_KEY = '';
+    process.env.GEMINI_API_KEY = '';
+
+    const compressor = new Compressor({
+      now: () => new Date('2026-02-11T12:00:00.000Z')
+    });
+    const output = await compressor.compress(
+      [
+        'TODO: review the PR',
+        'we need to close the release checklist',
+        "don't forget to update the changelog",
+        'remember to rotate API keys',
+        'make sure to run smoke tests'
+      ],
+      ''
+    );
+
+    expect(output).toMatch(/\[todo\|c=\d\.\d{2}\|i=0\.(6\d|7\d|8\d|9\d)\].*TODO: review the PR/i);
+    expect(output).toMatch(/\[todo\|c=\d\.\d{2}\|i=0\.(6\d|7\d|8\d|9\d)\].*we need to close the release checklist/i);
+    expect(output).toMatch(/\[todo\|c=\d\.\d{2}\|i=0\.(6\d|7\d|8\d|9\d)\].*don't forget to update the changelog/i);
+    expect(output).toMatch(/\[todo\|c=\d\.\d{2}\|i=0\.(6\d|7\d|8\d|9\d)\].*remember to rotate API keys/i);
+    expect(output).toMatch(/\[todo\|c=\d\.\d{2}\|i=0\.(6\d|7\d|8\d|9\d)\].*make sure to run smoke tests/i);
+  });
+
+  it('detects commitment phrasing as task observations', async () => {
+    process.env.ANTHROPIC_API_KEY = '';
+    process.env.OPENAI_API_KEY = '';
+    process.env.GEMINI_API_KEY = '';
+
+    const compressor = new Compressor({
+      now: () => new Date('2026-02-11T12:00:00.000Z')
+    });
+    const output = await compressor.compress(
+      [
+        "I'll deploy after lunch",
+        'I will prepare the migration plan',
+        'let me open a bug ticket',
+        'going to add rollback checks',
+        'plan to share release notes',
+        'should add a post-deploy monitor'
+      ],
+      ''
+    );
+
+    expect(output).toMatch(/\[task\|c=\d\.\d{2}\|i=0\.(6\d|7\d|8\d|9\d)\].*I'll deploy after lunch/i);
+    expect(output).toMatch(/\[task\|c=\d\.\d{2}\|i=0\.(6\d|7\d|8\d|9\d)\].*I will prepare the migration plan/i);
+    expect(output).toMatch(/\[task\|c=\d\.\d{2}\|i=0\.(6\d|7\d|8\d|9\d)\].*let me open a bug ticket/i);
+    expect(output).toMatch(/\[task\|c=\d\.\d{2}\|i=0\.(6\d|7\d|8\d|9\d)\].*going to add rollback checks/i);
+    expect(output).toMatch(/\[task\|c=\d\.\d{2}\|i=0\.(6\d|7\d|8\d|9\d)\].*plan to share release notes/i);
+    expect(output).toMatch(/\[task\|c=\d\.\d{2}\|i=0\.(6\d|7\d|8\d|9\d)\].*should add a post-deploy monitor/i);
+  });
+
+  it('deduplicates repeated TODO observations during merges', async () => {
+    process.env.ANTHROPIC_API_KEY = '';
+    process.env.GEMINI_API_KEY = '';
+    process.env.OPENAI_API_KEY = 'test-key';
+
+    const fetchImpl: typeof fetch = async () => {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: [
+                  '## 2026-02-11',
+                  '',
+                  '- [todo|c=0.84|i=0.66] 10:30 TODO: fix flaky tests'
+                ].join('\n')
+              }
+            }
+          ]
+        })
+      } as Response;
+    };
+
+    const compressor = new Compressor({
+      now: () => new Date('2026-02-11T10:30:00.000Z'),
+      fetchImpl
+    });
+
+    const existing = '## 2026-02-11\n\n- [todo|c=0.83|i=0.65] 09:00 TODO: fix flaky tests';
+    const merged = await compressor.compress(['merge updates'], existing);
+
+    expect((merged.match(/TODO: fix flaky tests/g) ?? []).length).toBe(1);
+  });
 });

--- a/src/observer/compressor.ts
+++ b/src/observer/compressor.ts
@@ -18,6 +18,10 @@ const CRITICAL_RE =
   /(?:\b(?:decision|decided|chose|chosen|selected|picked|opted|switched to)\s*:?|\bdecid(?:e|ed|ing|ion)\b|\berror\b|\bfail(?:ed|ure|ing)?\b|\bblock(?:ed|er)?\b|\bbreaking(?:\s+change)?s?\b|\bcritical\b|\b\w+\s+chosen\s+(?:for|over|as)\b|\bpublish(?:ed)?\b.*@?\d+\.\d+|\bmerge[d]?\s+(?:PR|pull\s+request)\b|\bshipped\b|\breleased?\b.*v?\d+\.\d+|\bsigned\b.*\b(?:contract|agreement|deal)\b|\bpricing\b.*\$|\bdemo\b.*\b(?:completed?|done|finished)\b|\bmeeting\b.*\b(?:completed?|done|finished)\b|\bstrategy\b.*\b(?:pivot|change|shift)\b)/i;
 const DEADLINE_WITH_DATE_RE = /(?:(?:\bdeadline\b|\bdue(?:\s+date)?\b|\bcutoff\b).*(?:\d{4}-\d{2}-\d{2}|\d{1,2}\/\d{1,2}(?:\/\d{2,4})?|(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s+\d{1,2})|(?:\d{4}-\d{2}-\d{2}|\d{1,2}\/\d{1,2}(?:\/\d{2,4})?|(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s+\d{1,2}).*(?:\bdeadline\b|\bdue(?:\s+date)?\b|\bcutoff\b))/i;
 const NOTABLE_RE = /\b(prefer(?:ence|s)?|likes?|dislikes?|context|pattern|architecture|approach|trade[- ]?off|milestone|stakeholder|teammate|collaborat(?:e|ed|ion)|discussion|notable|deadline|due|timeline|deploy(?:ed|ment)?|built|configured|launched|proposal|pitch|onboard(?:ed|ing)?|migrat(?:e|ed|ion)|domain|DNS|infra(?:structure)?)\b/i;
+const TODO_SIGNAL_RE = /(?:\btodo:\s*|\bwe need to\b|\bdon't forget(?: to)?\b|\bremember to\b|\bmake sure to\b)/i;
+const COMMITMENT_TASK_SIGNAL_RE = /\b(?:i'?ll|i will|let me|(?:i'?m\s+)?going to|plan to|should)\b/i;
+const UNRESOLVED_COMMITMENT_RE = /\b(?:need to figure out|tbd|to be determined)\b/i;
+const DEADLINE_SIGNAL_RE = /\b(?:by\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|tomorrow)|before\s+the\s+\w+|deadline is)\b/i;
 
 export class Compressor {
   private readonly model?: string;
@@ -81,12 +85,18 @@ export class Compressor {
       '- Output markdown only.',
       '- Group observations by date heading: ## YYYY-MM-DD',
       '- Each observation line MUST follow: - [type|c=<0.00-1.00>|i=<0.00-1.00>] <observation>',
-      '- Allowed type tags: decision, preference, fact, commitment, milestone, lesson, relationship, project',
+      '- Allowed type tags: decision, preference, fact, commitment, task, todo, commitment-unresolved, milestone, lesson, relationship, project',
       '- i >= 0.80 for structural/persistent observations (major decisions, blockers, releases, commitments)',
       '- i 0.40-0.79 for potentially important observations (notable context, preferences, milestones)',
       '- i < 0.40 for contextual/routine observations',
       '- Confidence c reflects extraction certainty, not importance.',
       '- Preserve source tags when present (e.g., [main], [telegram-dm], [discord], [telegram-group]).',
+      '',
+      'TASK EXTRACTION (required):',
+      '- Emit [todo] for explicit TODO phrasing: "TODO:", "we need to", "don\'t forget", "remember to", "make sure to".',
+      '- Emit [task] for commitments/action intent: "I\'ll", "I will", "let me", "going to", "plan to", "should".',
+      '- Emit [commitment-unresolved] for unresolved commitments/questions: "need to figure out", "TBD", "to be determined".',
+      '- Deadline language ("by Friday", "before the demo", "deadline is") should increase importance and usually map to [task] unless unresolved.',
       '',
       'QUALITY FILTERS (important):',
       '- DO NOT observe: CLI errors, command failures, tool output parsing issues, retry attempts, debug logs.',
@@ -297,6 +307,7 @@ export class Compressor {
     let importance = record.importance;
     let confidence = record.confidence;
     let type = record.type;
+    const inferredTaskType = this.inferTaskType(record.content);
 
     if (this.isCriticalContent(record.content)) {
       importance = Math.max(importance, 0.85);
@@ -307,6 +318,12 @@ export class Compressor {
     } else if (this.isNotableContent(record.content)) {
       importance = Math.max(importance, 0.5);
       confidence = Math.max(confidence, 0.75);
+    }
+
+    if (inferredTaskType) {
+      type = type === 'fact' || type === 'commitment' ? inferredTaskType : type;
+      importance = Math.max(importance, inferredTaskType === 'commitment-unresolved' ? 0.72 : 0.65);
+      confidence = Math.max(confidence, 0.8);
     }
 
     if (type === 'decision' || type === 'commitment' || type === 'milestone') {
@@ -450,7 +467,10 @@ export class Compressor {
   }
 
   private inferImportance(text: string, type: ObservationType): number {
+    const inferredTaskType = this.inferTaskType(text);
     if (this.isCriticalContent(text)) return 0.9;
+    if (inferredTaskType === 'commitment-unresolved') return 0.72;
+    if (inferredTaskType === 'task' || inferredTaskType === 'todo') return 0.65;
     if (this.isNotableContent(text)) return 0.6;
     if (type === 'decision' || type === 'commitment' || type === 'milestone') return 0.55;
     if (type === 'preference' || type === 'lesson' || type === 'relationship' || type === 'project') return 0.45;
@@ -458,9 +478,11 @@ export class Compressor {
   }
 
   private inferConfidence(text: string, type: ObservationType, importance: number): number {
+    const inferredTaskType = this.inferTaskType(text);
     let confidence = 0.72;
     if (importance >= 0.8) confidence += 0.12;
     if (type === 'decision' || type === 'commitment' || type === 'milestone') confidence += 0.06;
+    if (inferredTaskType) confidence += 0.06;
     if (/\b(?:decided|chose|committed|deadline|released|merged)\b/i.test(text)) {
       confidence += 0.05;
     }
@@ -473,6 +495,19 @@ export class Compressor {
 
   private isNotableContent(text: string): boolean {
     return NOTABLE_RE.test(text);
+  }
+
+  private inferTaskType(text: string): 'task' | 'todo' | 'commitment-unresolved' | null {
+    if (UNRESOLVED_COMMITMENT_RE.test(text)) {
+      return 'commitment-unresolved';
+    }
+    if (TODO_SIGNAL_RE.test(text)) {
+      return 'todo';
+    }
+    if (COMMITMENT_TASK_SIGNAL_RE.test(text) || DEADLINE_SIGNAL_RE.test(text)) {
+      return 'task';
+    }
+    return null;
   }
 
   private normalizeText(text: string): string {

--- a/src/observer/observer.ts
+++ b/src/observer/observer.ts
@@ -34,6 +34,7 @@ export interface ObserverOptions {
   reflector?: ObserverReflector;
   now?: () => Date;
   rawCapture?: boolean;
+  extractTasks?: boolean;
 }
 
 export interface ObserverProcessOptions {
@@ -56,6 +57,7 @@ export class Observer {
 
   private readonly router: Router;
   private pendingMessages: string[] = [];
+  private pendingRouteContext: ObserverProcessOptions = {};
   private observationsCache = '';
   private lastRoutingSummary = '';
 
@@ -68,7 +70,10 @@ export class Observer {
     this.reflector = options.reflector ?? new Reflector({ now: this.now });
     this.rawCapture = options.rawCapture ?? true;
 
-    this.router = new Router(vaultPath);
+    this.router = new Router(vaultPath, {
+      extractTasks: options.extractTasks,
+      now: this.now
+    });
 
     ensureLedgerStructure(this.vaultPath);
     this.observationsCache = this.readTodayObservations();
@@ -85,6 +90,7 @@ export class Observer {
     }
 
     this.pendingMessages.push(...incoming);
+    this.pendingRouteContext = this.mergeRouteContext(this.pendingRouteContext, options);
     const buffered = this.pendingMessages.join('\n');
     if (this.estimateTokens(buffered) < this.tokenThreshold) {
       return;
@@ -98,7 +104,9 @@ export class Observer {
       this.writeObservationFile(todayPath, existing);
     }
     const compressedRaw = (await this.compressor.compress(this.pendingMessages, existing)).trim();
+    const routeContext = this.pendingRouteContext;
     this.pendingMessages = [];
+    this.pendingRouteContext = {};
     const compressed = this.deduplicateObservationMarkdown(compressedRaw);
 
     if (!compressed) {
@@ -109,7 +117,7 @@ export class Observer {
     this.observationsCache = compressed;
 
     // Route observations to vault categories (decisions/, lessons/, etc.)
-    const { summary } = this.router.route(compressed);
+    const { summary } = this.router.route(compressed, routeContext);
     if (summary) {
       this.lastRoutingSummary = summary;
     }
@@ -132,13 +140,15 @@ export class Observer {
       this.writeObservationFile(todayPath, existing);
     }
     const compressedRaw = (await this.compressor.compress(this.pendingMessages, existing)).trim();
+    const routeContext = this.pendingRouteContext;
     this.pendingMessages = [];
+    this.pendingRouteContext = {};
     const compressed = this.deduplicateObservationMarkdown(compressedRaw);
 
     if (compressed) {
       this.writeObservationFile(todayPath, compressed);
       this.observationsCache = compressed;
-      const { summary } = this.router.route(compressed);
+      const { summary } = this.router.route(compressed, routeContext);
       this.lastRoutingSummary = summary;
     }
 
@@ -248,5 +258,17 @@ export class Observer {
       return normalized;
     }
     return 'openclaw';
+  }
+
+  private mergeRouteContext(
+    existing: ObserverProcessOptions,
+    incoming: ObserverProcessOptions
+  ): ObserverProcessOptions {
+    const merged: ObserverProcessOptions = { ...existing };
+    if (incoming.source) merged.source = incoming.source;
+    if (incoming.sessionKey) merged.sessionKey = incoming.sessionKey;
+    if (incoming.transcriptId) merged.transcriptId = incoming.transcriptId;
+    if (incoming.timestamp) merged.timestamp = incoming.timestamp;
+    return merged;
   }
 }

--- a/src/observer/router.test.ts
+++ b/src/observer/router.test.ts
@@ -75,4 +75,64 @@ describe('Router', () => {
       fs.rmSync(vaultPath, { recursive: true, force: true });
     }
   });
+
+  it('routes task and todo observations into backlog with observer source/context', () => {
+    const vaultPath = makeTempVault();
+    const router = new Router(vaultPath);
+
+    const markdown = [
+      '## 2026-02-11',
+      '',
+      '- [todo|c=0.86|i=0.66] 10:05 TODO: review the PR before the demo',
+      "- [task|c=0.83|i=0.65] 10:10 I'll deploy the patch by Friday"
+    ].join('\n');
+
+    try {
+      const { routed } = router.route(markdown, {
+        source: 'openclaw',
+        sessionKey: 'agent:clawdious:main',
+        transcriptId: 'session-abc',
+        timestamp: new Date('2026-02-11T10:15:00.000Z')
+      });
+
+      const backlogItems = routed.filter((item) => item.category === 'backlog');
+      expect(backlogItems).toHaveLength(2);
+
+      const backlogDir = path.join(vaultPath, 'backlog');
+      const backlogFiles = fs.readdirSync(backlogDir).filter((entry) => entry.endsWith('.md'));
+      expect(backlogFiles).toHaveLength(2);
+
+      const joined = backlogFiles
+        .map((file) => fs.readFileSync(path.join(backlogDir, file), 'utf-8'))
+        .join('\n');
+      expect(joined).toContain('source: observer');
+      expect(joined).toContain('Session: agent:clawdious:main');
+      expect(joined).toContain('Transcript: session-abc');
+      expect(joined).toContain('Approximate timestamp: 2026-02-11T10:15:00.000Z');
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+    }
+  });
+
+  it('deduplicates repeated task observations into a single backlog item', () => {
+    const vaultPath = makeTempVault();
+    const router = new Router(vaultPath);
+    const markdown = [
+      '## 2026-02-11',
+      '',
+      '- [todo|c=0.82|i=0.66] 09:00 TODO: fix flaky tests'
+    ].join('\n');
+
+    try {
+      router.route(markdown, { sessionKey: 'agent:clawdious:main' });
+      const second = router.route(markdown, { sessionKey: 'agent:clawdious:main' });
+
+      const backlogDir = path.join(vaultPath, 'backlog');
+      const backlogFiles = fs.readdirSync(backlogDir).filter((entry) => entry.endsWith('.md'));
+      expect(backlogFiles).toHaveLength(1);
+      expect(second.summary).toContain('dedup hits: 1');
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/observer/router.ts
+++ b/src/observer/router.ts
@@ -7,6 +7,15 @@ import {
   renderScoredObservationLine,
   type ObservationType
 } from '../lib/observation-format.js';
+import {
+  createBacklogItem,
+  listBacklogItems,
+  listTasks,
+  updateBacklogItem,
+  updateTask,
+  type BacklogItem,
+  type Task
+} from '../lib/task-utils.js';
 
 /**
  * Routes observations into the appropriate vault category files.
@@ -21,6 +30,27 @@ interface RoutedItem {
   confidence: number;
   importance: number;
   date: string;
+}
+
+interface RouterOptions {
+  extractTasks?: boolean;
+  now?: () => Date;
+}
+
+export interface RouteContext {
+  source?: string;
+  sessionKey?: string;
+  transcriptId?: string;
+  timestamp?: Date;
+}
+
+interface ExistingWorkItem {
+  kind: 'task' | 'backlog';
+  slug: string;
+  title: string;
+  status: string;
+  source?: string;
+  tags: string[];
 }
 
 const CATEGORY_PATTERNS: Array<{ category: string; patterns: RegExp[] }> = [
@@ -77,6 +107,9 @@ const TYPE_TO_CATEGORY: Record<ObservationType, string> = {
   preference: 'preferences',
   fact: 'facts',
   commitment: 'commitments',
+  task: 'commitments',
+  todo: 'commitments',
+  'commitment-unresolved': 'commitments',
   milestone: 'projects',
   lesson: 'lessons',
   relationship: 'people',
@@ -85,9 +118,13 @@ const TYPE_TO_CATEGORY: Record<ObservationType, string> = {
 
 export class Router {
   private readonly vaultPath: string;
+  private readonly extractTasks: boolean;
+  private readonly now: () => Date;
 
-  constructor(vaultPath: string) {
+  constructor(vaultPath: string, options: RouterOptions = {}) {
     this.vaultPath = path.resolve(vaultPath);
+    this.extractTasks = options.extractTasks ?? true;
+    this.now = options.now ?? (() => new Date());
   }
 
   /**
@@ -95,12 +132,28 @@ export class Router {
    * Routes only items with importance >= 0.4.
    * Returns a summary of what was routed where.
    */
-  route(observationMarkdown: string): { routed: RoutedItem[]; summary: string } {
+  route(
+    observationMarkdown: string,
+    context: RouteContext = {}
+  ): { routed: RoutedItem[]; summary: string } {
     const items = this.parseObservations(observationMarkdown);
     const routed: RoutedItem[] = [];
+    const knownWorkItems = this.extractTasks ? this.loadExistingWorkItems() : [];
+    let dedupHits = 0;
 
     for (const item of items) {
       if (item.importance < 0.4) continue;
+
+      if (this.extractTasks && this.isTaskObservation(item.type)) {
+        const taskResult = this.routeTaskObservation(item, context, knownWorkItems);
+        if (taskResult.routedItem) {
+          routed.push(taskResult.routedItem);
+        }
+        if (taskResult.dedupHit) {
+          dedupHits += 1;
+        }
+        continue;
+      }
 
       const category = this.categorize(item.type, item.content);
       if (!category) continue;
@@ -118,8 +171,263 @@ export class Router {
       this.appendToCategory(category, routedItem);
     }
 
-    const summary = this.buildSummary(routed);
+    const summary = this.buildSummary(routed, dedupHits);
     return { routed, summary };
+  }
+
+  private isTaskObservation(
+    type: ObservationType
+  ): type is 'task' | 'todo' | 'commitment-unresolved' {
+    return type === 'task' || type === 'todo' || type === 'commitment-unresolved';
+  }
+
+  private routeTaskObservation(
+    item: {
+      type: ObservationType;
+      confidence: number;
+      importance: number;
+      content: string;
+      date: string;
+      title: string;
+    },
+    context: RouteContext,
+    knownWorkItems: ExistingWorkItem[]
+  ): { routedItem: RoutedItem | null; dedupHit: boolean } {
+    const title = this.deriveTaskTitle(item.content, item.type);
+    if (!title) {
+      return { routedItem: null, dedupHit: false };
+    }
+
+    const duplicate = this.findDuplicateWorkItem(title, knownWorkItems);
+    if (duplicate) {
+      if (item.type === 'commitment-unresolved' && this.isOpenWorkItem(duplicate)) {
+        this.touchExistingWorkItem(duplicate);
+      }
+      console.log(`[observer] dedup hit for task candidate: "${title}"`);
+      return { routedItem: null, dedupHit: true };
+    }
+
+    const tags = this.mergeTags(
+      ['open', 'observer'],
+      item.type === 'task' ? ['task'] : [],
+      item.type === 'todo' ? ['todo'] : [],
+      item.type === 'commitment-unresolved' ? ['commitment'] : []
+    );
+
+    const content = this.buildTaskContextContent(item, context);
+    let backlogItem: BacklogItem;
+    try {
+      backlogItem = createBacklogItem(this.vaultPath, title, {
+        source: 'observer',
+        content,
+        tags
+      });
+    } catch (error) {
+      if (error instanceof Error && /already exists/i.test(error.message)) {
+        console.log(`[observer] dedup hit for task candidate: "${title}"`);
+        return { routedItem: null, dedupHit: true };
+      }
+      throw error;
+    }
+
+    knownWorkItems.push({
+      kind: 'backlog',
+      slug: backlogItem.slug,
+      title: backlogItem.title,
+      status: 'open',
+      source: backlogItem.frontmatter.source,
+      tags: backlogItem.frontmatter.tags ?? []
+    });
+
+    return {
+      dedupHit: false,
+      routedItem: {
+        category: 'backlog',
+        title: backlogItem.title,
+        content: item.content,
+        type: item.type,
+        confidence: item.confidence,
+        importance: item.importance,
+        date: item.date
+      }
+    };
+  }
+
+  private loadExistingWorkItems(): ExistingWorkItem[] {
+    const taskItems: ExistingWorkItem[] = listTasks(this.vaultPath).map((task: Task) => ({
+      kind: 'task',
+      slug: task.slug,
+      title: task.title,
+      status: task.frontmatter.status,
+      source: task.frontmatter.source,
+      tags: task.frontmatter.tags ?? []
+    }));
+    const backlogItems: ExistingWorkItem[] = listBacklogItems(this.vaultPath).map((item: BacklogItem) => ({
+      kind: 'backlog',
+      slug: item.slug,
+      title: item.title,
+      status: item.frontmatter.tags?.includes('done') ? 'done' : 'open',
+      source: item.frontmatter.source,
+      tags: item.frontmatter.tags ?? []
+    }));
+    return [...taskItems, ...backlogItems];
+  }
+
+  private findDuplicateWorkItem(title: string, knownWorkItems: ExistingWorkItem[]): ExistingWorkItem | null {
+    const normalizedTitle = this.normalizeTaskTitle(title);
+    if (!normalizedTitle) {
+      return null;
+    }
+
+    for (const item of knownWorkItems) {
+      const normalizedExisting = this.normalizeTaskTitle(item.title);
+      if (!normalizedExisting) {
+        continue;
+      }
+      if (normalizedExisting === normalizedTitle) {
+        return item;
+      }
+      if (this.jaccardWordSimilarity(normalizedTitle, normalizedExisting) > 0.8) {
+        return item;
+      }
+    }
+
+    return null;
+  }
+
+  private normalizeTaskTitle(title: string): string {
+    return title
+      .toLowerCase()
+      .replace(/[^\w\s]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 50);
+  }
+
+  private jaccardWordSimilarity(a: string, b: string): number {
+    const aWords = new Set(a.split(' ').filter(Boolean));
+    const bWords = new Set(b.split(' ').filter(Boolean));
+    if (aWords.size === 0 || bWords.size === 0) {
+      return 0;
+    }
+
+    let intersection = 0;
+    for (const word of aWords) {
+      if (bWords.has(word)) {
+        intersection += 1;
+      }
+    }
+    const unionSize = aWords.size + bWords.size - intersection;
+    return unionSize === 0 ? 0 : intersection / unionSize;
+  }
+
+  private deriveTaskTitle(content: string, type: ObservationType): string {
+    let title = content
+      .replace(/^\d{2}:\d{2}\s+/, '')
+      .replace(/\[[^\]]+\]\s*/g, '')
+      .trim();
+
+    if (type === 'todo') {
+      title = title.replace(
+        /^(?:todo:\s*|we need to\s+|don't forget(?: to)?\s+|remember to\s+|make sure to\s+)/i,
+        ''
+      );
+    } else if (type === 'task') {
+      title = title.replace(
+        /^(?:i'?ll\s+|i will\s+|let me\s+|(?:i'?m\s+)?going to\s+|plan to\s+|should\s+)/i,
+        ''
+      );
+    } else if (type === 'commitment-unresolved') {
+      title = title.replace(/^(?:need to figure out\s+|tbd[:\s-]*|to be determined[:\s-]*)/i, '');
+    }
+
+    title = title
+      .replace(/\s+/g, ' ')
+      .replace(/^[^a-zA-Z0-9]+/, '')
+      .replace(/[.?!:;,]+$/, '')
+      .trim();
+
+    return title.slice(0, 120);
+  }
+
+  private buildTaskContextContent(
+    item: {
+      type: ObservationType;
+      content: string;
+      date: string;
+    },
+    context: RouteContext
+  ): string {
+    const lines: string[] = ['Auto-extracted by observer from session transcript.'];
+
+    if (context.sessionKey) {
+      lines.push(`Session: ${context.sessionKey}`);
+    }
+    if (context.transcriptId) {
+      lines.push(`Transcript: ${context.transcriptId}`);
+    }
+    if (context.source) {
+      lines.push(`Source: ${context.source}`);
+    }
+
+    const approximateTimestamp = this.extractApproximateTimestamp(item.date, item.content, context.timestamp);
+    lines.push(`Approximate timestamp: ${approximateTimestamp}`);
+    lines.push(`Observation type: ${item.type}`);
+    lines.push(`Original observation: ${item.content}`);
+    return lines.join('\n');
+  }
+
+  private extractApproximateTimestamp(
+    date: string,
+    content: string,
+    timestamp?: Date
+  ): string {
+    if (timestamp) {
+      return timestamp.toISOString();
+    }
+    const timeMatch = content.match(/\b([01]\d|2[0-3]):([0-5]\d)\b/);
+    if (timeMatch) {
+      return `${date} ${timeMatch[0]}`;
+    }
+    return date;
+  }
+
+  private isOpenWorkItem(item: ExistingWorkItem): boolean {
+    if (item.kind === 'task') {
+      return item.status !== 'done';
+    }
+    return item.status !== 'done';
+  }
+
+  private touchExistingWorkItem(item: ExistingWorkItem): void {
+    if (item.kind === 'task') {
+      if (!this.isOpenWorkItem(item)) {
+        return;
+      }
+      updateTask(this.vaultPath, item.slug, {});
+      return;
+    }
+
+    const nextTags = this.mergeTags(item.tags, ['commitment']);
+    updateBacklogItem(this.vaultPath, item.slug, {
+      source: item.source ?? 'observer',
+      tags: nextTags,
+      lastSeen: this.now().toISOString()
+    });
+    item.tags = nextTags;
+  }
+
+  private mergeTags(...groups: string[][]): string[] {
+    const merged = new Set<string>();
+    for (const group of groups) {
+      for (const tag of group) {
+        const normalized = tag.trim().toLowerCase();
+        if (normalized) {
+          merged.add(normalized);
+        }
+      }
+    }
+    return [...merged];
   }
 
   private parseObservations(markdown: string): Array<{
@@ -340,8 +648,13 @@ export class Router {
     return intersection / (setA.size + setB.size - intersection);
   }
 
-  private buildSummary(routed: RoutedItem[]): string {
-    if (routed.length === 0) return 'No items routed to vault categories.';
+  private buildSummary(routed: RoutedItem[], dedupHits: number): string {
+    if (routed.length === 0) {
+      if (dedupHits > 0) {
+        return `No items routed to vault categories (dedup hits: ${dedupHits}).`;
+      }
+      return 'No items routed to vault categories.';
+    }
 
     const byCat = new Map<string, number>();
     for (const item of routed) {
@@ -349,6 +662,7 @@ export class Router {
     }
 
     const parts = [...byCat.entries()].map(([cat, count]) => `${cat}: ${count}`);
-    return `Routed ${routed.length} observations → ${parts.join(', ')}`;
+    const suffix = dedupHits > 0 ? ` (dedup hits: ${dedupHits})` : '';
+    return `Routed ${routed.length} observations → ${parts.join(', ')}${suffix}`;
   }
 }


### PR DESCRIPTION
Implement observer auto-task detection to automatically extract, type, and route tasks, todos, and unresolved commitments from observations into the backlog with deduplication.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e05c3bd7-0516-4668-954a-566aa7a809b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e05c3bd7-0516-4668-954a-566aa7a809b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

