### PR TITLE
Observer reliability and cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Auto-compress conversations into prioritized observations. Critical items route 
 ```bash
 clawvault observe --compress session.md      # One-shot compression
 clawvault observe --active                   # Incremental from transcripts
+clawvault observe --cron                     # Cron-safe one-shot summary + exit code
 ```
 
 ### 🛡️ Context Death Recovery

--- a/bin/register-query-commands.js
+++ b/bin/register-query-commands.js
@@ -214,6 +214,7 @@ export function registerQueryCommands(
     .description('Observe session files and build observational memory')
     .option('--watch <path>', 'Watch session file or directory')
     .option('--active', 'Observe active OpenClaw sessions incrementally')
+    .option('--cron', 'Run one-shot active observation for cron hooks')
     .option('--agent <id>', 'OpenClaw agent ID (default: OPENCLAW_AGENT_ID or clawdious)')
     .option('--min-new <bytes>', 'Override minimum new-content threshold in bytes')
     .option('--sessions-dir <path>', 'Override OpenClaw sessions directory')
@@ -245,6 +246,7 @@ export function registerQueryCommands(
         await observeCommand({
           watch: options.watch,
           active: options.active,
+          cron: options.cron,
           agent: options.agent,
           minNew,
           sessionsDir: options.sessionsDir,

--- a/hooks/clawvault/handler.js
+++ b/hooks/clawvault/handler.js
@@ -528,19 +528,23 @@ function resolveAgentIdForEvent(event) {
   return 'clawdious';
 }
 
-function runActiveObservation(vaultPath, agentId, options = {}) {
-  const args = ['observe', '--active', '--agent', agentId, '-v', vaultPath];
+function runObserverCron(vaultPath, agentId, options = {}) {
+  const args = ['observe', '--cron', '--agent', agentId, '-v', vaultPath];
   if (Number.isFinite(options.minNewBytes) && Number(options.minNewBytes) > 0) {
     args.push('--min-new', String(Math.floor(Number(options.minNewBytes))));
   }
 
   const result = runClawvault(args, { timeoutMs: 120000 });
   if (!result.success) {
-    console.warn(`[clawvault] Active observation failed (${options.reason || 'unknown reason'})`);
+    console.warn(`[clawvault] Observer cron failed (${options.reason || 'unknown reason'})`);
     return false;
   }
 
-  console.log(`[clawvault] Active observation complete (${options.reason || 'triggered'})`);
+  if (result.output) {
+    console.log(`[clawvault] Observer cron: ${result.output}`);
+  } else {
+    console.log('[clawvault] Observer cron: complete');
+  }
   return true;
 }
 
@@ -659,7 +663,7 @@ async function handleNew(event) {
   }
 
   const agentId = resolveAgentIdForEvent(event);
-  runActiveObservation(vaultPath, agentId, {
+  runObserverCron(vaultPath, agentId, {
     minNewBytes: 1,
     reason: 'command:new flush'
   });
@@ -741,7 +745,7 @@ async function handleHeartbeat(event) {
     return;
   }
 
-  runActiveObservation(vaultPath, agentId, { reason: 'heartbeat threshold crossed' });
+  runObserverCron(vaultPath, agentId, { reason: 'heartbeat threshold crossed' });
 }
 
 // Handle context compaction - force flush any pending session deltas
@@ -753,7 +757,7 @@ async function handleContextCompaction(event) {
   }
 
   const agentId = resolveAgentIdForEvent(event);
-  runActiveObservation(vaultPath, agentId, {
+  runObserverCron(vaultPath, agentId, {
     minNewBytes: 1,
     reason: 'context compaction'
   });

--- a/hooks/clawvault/handler.test.js
+++ b/hooks/clawvault/handler.test.js
@@ -213,7 +213,7 @@ describe('clawvault hook handler', () => {
 
     expect(execFileSyncMock).toHaveBeenCalledWith(
       'clawvault',
-      expect.arrayContaining(['observe', '--active', '--agent', 'clawdious']),
+      expect.arrayContaining(['observe', '--cron', '--agent', 'clawdious']),
       expect.objectContaining({ shell: false })
     );
 
@@ -234,7 +234,7 @@ describe('clawvault hook handler', () => {
 
     expect(execFileSyncMock).toHaveBeenCalledWith(
       'clawvault',
-      expect.arrayContaining(['observe', '--active', '--min-new', '1']),
+      expect.arrayContaining(['observe', '--cron', '--min-new', '1']),
       expect.objectContaining({ shell: false })
     );
 

--- a/scripts/observe-active-sessions.sh
+++ b/scripts/observe-active-sessions.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 CLAWVAULT_BIN="${CLAWVAULT_BIN:-clawvault}"
 
-ARGS=(observe --active)
+ARGS=(observe --cron)
 
 if [[ -n "${CLAWVAULT_AGENT_ID:-}" ]]; then
   ARGS+=(--agent "${CLAWVAULT_AGENT_ID}")

--- a/scripts/observe-stale-sessions.sh
+++ b/scripts/observe-stale-sessions.sh
@@ -51,7 +51,7 @@ fi
 run_stale_mode() {
   # Legacy stale sweep behavior: force observation for any unseen session delta.
   local min_new="${CLAWVAULT_STALE_MIN_NEW:-1}"
-  "${CLAWVAULT_BIN}" observe --active --min-new "${min_new}" "${BASE_ARGS[@]}" "${EXTRA_ARGS[@]}"
+  "${CLAWVAULT_BIN}" observe --cron --min-new "${min_new}" "${BASE_ARGS[@]}" "${EXTRA_ARGS[@]}"
 }
 
 run_active_mode() {

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -1,11 +1,12 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-const { hasQmdMock, scanVaultLinksMock } = vi.hoisted(() => ({
+const { hasQmdMock, scanVaultLinksMock, getObserverStalenessMock } = vi.hoisted(() => ({
   hasQmdMock: vi.fn(),
-  scanVaultLinksMock: vi.fn()
+  scanVaultLinksMock: vi.fn(),
+  getObserverStalenessMock: vi.fn()
 }));
 
 let mockStats = { documents: 0, categories: {} as Record<string, number> };
@@ -33,6 +34,10 @@ vi.mock('../lib/search.js', async () => {
 
 vi.mock('../lib/backlinks.js', () => ({
   scanVaultLinks: scanVaultLinksMock
+}));
+
+vi.mock('../observer/active-session-observer.js', () => ({
+  getObserverStaleness: getObserverStalenessMock
 }));
 
 vi.mock('../lib/vault.js', () => ({
@@ -100,6 +105,14 @@ afterEach(() => {
   process.env.SHELL = envSnapshot.SHELL;
 });
 
+beforeEach(() => {
+  getObserverStalenessMock.mockReturnValue({
+    staleCount: 0,
+    oldestMs: 0,
+    newestMs: 0
+  });
+});
+
 describe('doctor', () => {
   it('reports when qmd is unavailable', async () => {
     hasQmdMock.mockReturnValue(false);
@@ -145,6 +158,41 @@ describe('doctor', () => {
         'orphan links',
         'inbox backlog'
       ]));
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+      fs.rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it('warns when observer cursors are stale', async () => {
+    hasQmdMock.mockReturnValue(true);
+    getObserverStalenessMock.mockReturnValue({
+      staleCount: 3,
+      oldestMs: 36 * 60 * 60 * 1000,
+      newestMs: 13 * 60 * 60 * 1000
+    });
+    scanVaultLinksMock.mockReturnValue({
+      backlinks: new Map(),
+      orphans: [],
+      linkCount: 0
+    });
+
+    const vaultPath = makeTempDir('clawvault-doctor-observer-');
+    const homePath = makeTempDir('clawvault-home-observer-');
+    process.env.HOME = homePath;
+    process.env.SHELL = '/bin/bash';
+    fs.writeFileSync(path.join(homePath, '.bashrc'), 'export CLAWVAULT_PATH="/tmp/vault"');
+
+    mockStats = { documents: 10, categories: { inbox: 1 } };
+    mockDocuments = [makeDoc('projects', new Date())];
+    mockHandoffs = [makeDoc('handoffs', new Date())];
+    mockInbox = [makeDoc('inbox', new Date())];
+
+    try {
+      const report = await doctor(vaultPath);
+      const observerCheck = report.checks.find((check) => check.label === 'observer freshness');
+      expect(observerCheck?.status).toBe('warn');
+      expect(observerCheck?.detail).toContain('3 stale session cursor(s)');
     } finally {
       fs.rmSync(vaultPath, { recursive: true, force: true });
       fs.rmSync(homePath, { recursive: true, force: true });

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -6,6 +6,7 @@ import { scanVaultLinks } from '../lib/backlinks.js';
 import { formatAge } from '../lib/time.js';
 import { hasQmd } from '../lib/search.js';
 import { loadMemoryGraphIndex } from '../lib/memory-graph.js';
+import { getObserverStaleness } from '../observer/active-session-observer.js';
 import { checkOpenClawCompatibility } from './compat.js';
 
 const CLAWVAULT_DIR = '.clawvault';
@@ -297,6 +298,22 @@ export async function doctor(vaultPath?: string): Promise<DoctorReport> {
         detail: `Last checkpoint ${ageLabel} ago`
       });
     }
+  }
+
+  const observerStaleness = getObserverStaleness(vault.getPath());
+  if (observerStaleness.staleCount > 0) {
+    checks.push({
+      label: 'observer freshness',
+      status: 'warn',
+      detail: `${observerStaleness.staleCount} stale session cursor(s); oldest ${formatAge(observerStaleness.oldestMs)} ago`,
+      hint: 'Run `clawvault observe --cron` and verify cron/hook scheduling.'
+    });
+    warnings++;
+  } else {
+    checks.push({
+      label: 'observer freshness',
+      status: 'ok'
+    });
   }
 
   const linkScan = scanVaultLinks(vault.getPath());

--- a/src/commands/observe.test.ts
+++ b/src/commands/observe.test.ts
@@ -98,6 +98,10 @@ describe('observeCommand', () => {
       cursorUpdates: 1,
       dryRun: false,
       totalNewBytes: 2048,
+      observedNewBytes: 2048,
+      routedCounts: {},
+      failedSessionCount: 0,
+      failedSessions: [],
       candidates: [
         {
           sessionId: 'abc',
@@ -132,5 +136,95 @@ describe('observeCommand', () => {
     expect(processMessagesMock).not.toHaveBeenCalled();
 
     logSpy.mockRestore();
+  });
+
+  it('prints one-line cron summary when observations are processed', async () => {
+    observeActiveSessionsMock.mockResolvedValue({
+      agentId: 'clawdious',
+      sessionsDir: '/tmp/sessions',
+      checkedSessions: 4,
+      candidateSessions: 3,
+      observedSessions: 3,
+      cursorUpdates: 3,
+      dryRun: false,
+      totalNewBytes: 47_180,
+      observedNewBytes: 45 * 1024,
+      routedCounts: { decisions: 2, lessons: 1 },
+      failedSessionCount: 0,
+      failedSessions: [],
+      candidates: []
+    });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await observeCommand({
+      vaultPath: '/tmp/vault',
+      cron: true,
+      threshold: 10,
+      reflectThreshold: 20
+    });
+
+    expect(logSpy).toHaveBeenCalledWith('observed 3 sessions, 45KB new content, 2 decisions extracted');
+    logSpy.mockRestore();
+  });
+
+  it('prints "nothing new" for cron when no sessions cross threshold', async () => {
+    observeActiveSessionsMock.mockResolvedValue({
+      agentId: 'clawdious',
+      sessionsDir: '/tmp/sessions',
+      checkedSessions: 2,
+      candidateSessions: 0,
+      observedSessions: 0,
+      cursorUpdates: 0,
+      dryRun: false,
+      totalNewBytes: 0,
+      observedNewBytes: 0,
+      routedCounts: {},
+      failedSessionCount: 0,
+      failedSessions: [],
+      candidates: []
+    });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await observeCommand({
+      vaultPath: '/tmp/vault',
+      cron: true,
+      threshold: 10,
+      reflectThreshold: 20
+    });
+
+    expect(logSpy).toHaveBeenCalledWith('nothing new');
+    logSpy.mockRestore();
+  });
+
+  it('throws in cron mode when any session observation fails', async () => {
+    observeActiveSessionsMock.mockResolvedValue({
+      agentId: 'clawdious',
+      sessionsDir: '/tmp/sessions',
+      checkedSessions: 3,
+      candidateSessions: 2,
+      observedSessions: 1,
+      cursorUpdates: 1,
+      dryRun: false,
+      totalNewBytes: 4096,
+      observedNewBytes: 2048,
+      routedCounts: {},
+      failedSessionCount: 1,
+      failedSessions: [
+        {
+          sessionId: 'session-2',
+          sessionKey: 'agent:clawdious:main',
+          sourceLabel: 'main',
+          error: 'Gemini timeout'
+        }
+      ],
+      candidates: []
+    });
+
+    await expect(observeCommand({
+      vaultPath: '/tmp/vault',
+      cron: true,
+      threshold: 10,
+      reflectThreshold: 20
+    })).rejects.toThrow('observer failed for 1 session(s)');
   });
 });

--- a/src/commands/observe.ts
+++ b/src/commands/observe.ts
@@ -9,6 +9,9 @@ import { observeActiveSessions } from '../observer/active-session-observer.js';
 import { resolveVaultPath } from '../lib/config.js';
 import { getObservationPath } from '../lib/ledger.js';
 
+const ONE_KIB = 1024;
+const ONE_MIB = ONE_KIB * ONE_KIB;
+
 export interface ObserveCommandOptions {
   watch?: string;
   threshold?: number;
@@ -23,6 +26,7 @@ export interface ObserveCommandOptions {
   minNew?: number;
   sessionsDir?: string;
   dryRun?: boolean;
+  cron?: boolean;
 }
 
 function parsePositiveInteger(raw: string, optionName: string): number {
@@ -60,6 +64,26 @@ function buildDaemonArgs(options: ObserveCommandOptions): string[] {
   }
 
   return args;
+}
+
+function formatByteSummary(bytes: number): string {
+  const normalized = Number.isFinite(bytes) ? Math.max(0, bytes) : 0;
+  if (normalized === 0) {
+    return '0KB';
+  }
+  if (normalized >= ONE_MIB) {
+    return `${(normalized / ONE_MIB).toFixed(1)}MB`;
+  }
+  return `${Math.max(1, Math.round(normalized / ONE_KIB))}KB`;
+}
+
+function formatCronSummary(result: {
+  observedSessions: number;
+  observedNewBytes: number;
+  routedCounts: Record<string, number>;
+}): string {
+  const decisionCount = result.routedCounts.decisions ?? 0;
+  return `observed ${result.observedSessions} sessions, ${formatByteSummary(result.observedNewBytes)} new content, ${decisionCount} decision${decisionCount === 1 ? '' : 's'} extracted`;
 }
 
 async function runOneShotCompression(
@@ -116,6 +140,14 @@ async function watchSessions(observer: Observer, watchPath: string): Promise<voi
 }
 
 export async function observeCommand(options: ObserveCommandOptions): Promise<void> {
+  if (options.cron && (options.active || options.watch || options.compress || options.daemon)) {
+    throw new Error('--cron cannot be combined with --active, --watch, --compress, or --daemon.');
+  }
+
+  if (options.cron && options.dryRun) {
+    throw new Error('--cron cannot be combined with --dry-run.');
+  }
+
   if (options.active && (options.watch || options.compress || options.daemon)) {
     throw new Error('--active cannot be combined with --watch, --compress, or --daemon.');
   }
@@ -126,7 +158,7 @@ export async function observeCommand(options: ObserveCommandOptions): Promise<vo
 
   const vaultPath = resolveVaultPath({ explicitPath: options.vaultPath });
 
-  if (options.active) {
+  if (options.active || options.cron) {
     const result = await observeActiveSessions({
       vaultPath,
       agentId: options.agent,
@@ -138,6 +170,31 @@ export async function observeCommand(options: ObserveCommandOptions): Promise<vo
       model: options.model,
       extractTasks: options.extractTasks
     });
+    const failedSessionCount = result.failedSessionCount ?? 0;
+
+    if (options.cron) {
+      if (failedSessionCount > 0) {
+        const firstFailure = result.failedSessions[0];
+        if (firstFailure) {
+          throw new Error(
+            `observer failed for ${failedSessionCount} session(s); first error: ${firstFailure.sessionKey} - ${firstFailure.error}`
+          );
+        }
+        throw new Error(`observer failed for ${failedSessionCount} session(s).`);
+      }
+
+      if (result.candidateSessions === 0) {
+        console.log('nothing new');
+        return;
+      }
+
+      console.log(formatCronSummary({
+        observedSessions: result.observedSessions,
+        observedNewBytes: result.observedNewBytes ?? result.totalNewBytes,
+        routedCounts: result.routedCounts ?? {}
+      }));
+      return;
+    }
 
     if (result.candidateSessions === 0) {
       console.log(`No active sessions crossed threshold (${result.checkedSessions} checked).`);
@@ -157,8 +214,15 @@ export async function observeCommand(options: ObserveCommandOptions): Promise<vo
     }
 
     console.log(
-      `Active observation complete: ${result.observedSessions}/${result.candidateSessions} session(s) observed.`
+      `Active observation complete: ${result.observedSessions}/${result.candidateSessions} session(s) observed.${failedSessionCount > 0 ? ` ${failedSessionCount} failed.` : ''}`
     );
+    if (failedSessionCount > 0) {
+      for (const failure of result.failedSessions) {
+        console.error(
+          `[observer] session failed ${failure.sessionKey} (${failure.sessionId}): ${failure.error}`
+        );
+      }
+    }
     return;
   }
 
@@ -211,6 +275,7 @@ export function registerObserveCommand(program: Command): void {
     .description('Observe session files and build observational memory')
     .option('--watch <path>', 'Watch session file or directory')
     .option('--active', 'Observe active OpenClaw sessions incrementally')
+    .option('--cron', 'Run one-shot active observation for cron hooks')
     .option('--agent <id>', 'OpenClaw agent ID (default: OPENCLAW_AGENT_ID or clawdious)')
     .option('--min-new <bytes>', 'Override minimum new-content threshold in bytes')
     .option('--sessions-dir <path>', 'Override OpenClaw sessions directory')
@@ -226,6 +291,7 @@ export function registerObserveCommand(program: Command): void {
     .action(async (rawOptions: {
       watch?: string;
       active?: boolean;
+      cron?: boolean;
       agent?: string;
       minNew?: string;
       sessionsDir?: string;
@@ -241,6 +307,7 @@ export function registerObserveCommand(program: Command): void {
       await observeCommand({
         watch: rawOptions.watch,
         active: rawOptions.active,
+        cron: rawOptions.cron,
         agent: rawOptions.agent,
         minNew: rawOptions.minNew ? parsePositiveInteger(rawOptions.minNew, 'min-new') : undefined,
         sessionsDir: rawOptions.sessionsDir,

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1,11 +1,12 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-const { execFileSyncMock, hasQmdMock } = vi.hoisted(() => ({
+const { execFileSyncMock, hasQmdMock, getObserverStalenessMock } = vi.hoisted(() => ({
   execFileSyncMock: vi.fn(),
-  hasQmdMock: vi.fn()
+  hasQmdMock: vi.fn(),
+  getObserverStalenessMock: vi.fn()
 }));
 
 let mockStats = { documents: 0, categories: {} as Record<string, number> };
@@ -23,6 +24,10 @@ vi.mock('../lib/search.js', async () => {
     hasQmd: hasQmdMock
   };
 });
+
+vi.mock('../observer/active-session-observer.js', () => ({
+  getObserverStaleness: getObserverStalenessMock
+}));
 
 vi.mock('../lib/vault.js', () => ({
   ClawVault: class {
@@ -67,6 +72,14 @@ function makeTempVaultDir(): string {
 
 afterEach(() => {
   vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  getObserverStalenessMock.mockReturnValue({
+    staleCount: 0,
+    oldestMs: 0,
+    newestMs: 0
+  });
 });
 
 describe('status command', () => {
@@ -169,7 +182,65 @@ describe('status command', () => {
       const formatted = formatStatus(status);
       expect(formatted).toContain('Issues: none');
       expect(formatted).toContain('Graph:');
+      expect(formatted).toContain('Observer:');
       expect(formatted).toContain('Links:');
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+    }
+  });
+
+  it('marks status warning when observer cursors are stale', async () => {
+    hasQmdMock.mockReturnValue(true);
+    getObserverStalenessMock.mockReturnValue({
+      staleCount: 2,
+      oldestMs: 48 * 60 * 60 * 1000,
+      newestMs: 13 * 60 * 60 * 1000
+    });
+    execFileSyncMock.mockImplementation((command: string) => {
+      if (command === 'qmd') {
+        return `Collections (1):\n\n${mockCollection} (qmd://${mockCollection}/)\n  Pattern: **/*.md\n  Root: ${mockRoot}\n`;
+      }
+      if (command === 'git') {
+        return '';
+      }
+      return '';
+    });
+
+    const vaultPath = makeTempVaultDir();
+    try {
+      fs.mkdirSync(path.join(vaultPath, '.git'), { recursive: true });
+      const clawvaultDir = path.join(vaultPath, '.clawvault');
+      fs.mkdirSync(clawvaultDir, { recursive: true });
+      const timestamp = new Date(Date.now() - 60_000).toISOString();
+      fs.writeFileSync(
+        path.join(clawvaultDir, 'last-checkpoint.json'),
+        JSON.stringify({ timestamp, workingOn: 'sync', focus: null, blocked: null }, null, 2)
+      );
+      fs.writeFileSync(
+        path.join(clawvaultDir, 'graph-index.json'),
+        JSON.stringify({
+          schemaVersion: 1,
+          vaultPath,
+          generatedAt: timestamp,
+          files: {},
+          graph: {
+            nodes: [],
+            edges: [],
+            stats: { nodeCount: 1, edgeCount: 0 }
+          }
+        }, null, 2)
+      );
+
+      mockStats = { documents: 1, categories: { inbox: 1 } };
+      mockCollection = 'vault';
+      mockRoot = vaultPath;
+
+      const status = await getStatus(vaultPath);
+      expect(status.health).toBe('warning');
+      expect(status.issues).toContain('Observer stale sessions: 2');
+      expect(status.observer.staleCount).toBe(2);
+      const formatted = formatStatus(status);
+      expect(formatted).toContain('Stale sessions: 2');
     } finally {
       fs.rmSync(vaultPath, { recursive: true, force: true });
     }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -6,6 +6,7 @@ import { hasQmd, QmdUnavailableError } from '../lib/search.js';
 import { formatAge } from '../lib/time.js';
 import { scanVaultLinks } from '../lib/backlinks.js';
 import { loadMemoryGraphIndex } from '../lib/memory-graph.js';
+import { getObserverStaleness } from '../observer/active-session-observer.js';
 import type { CheckpointData } from './checkpoint.js';
 
 export interface VaultStatus {
@@ -32,6 +33,11 @@ export interface VaultStatus {
     generatedAt?: string;
     nodeCount?: number;
     edgeCount?: number;
+  };
+  observer: {
+    staleCount: number;
+    oldestMs: number;
+    newestMs: number;
   };
   git?: {
     repoRoot: string;
@@ -233,6 +239,11 @@ export async function getStatus(vaultPath: string): Promise<VaultStatus> {
     }
   }
 
+  const observerStaleness = getObserverStaleness(vault.getPath());
+  if (observerStaleness.staleCount > 0) {
+    issues.push(`Observer stale sessions: ${observerStaleness.staleCount}`);
+  }
+
   return {
     vaultName: vault.getName(),
     vaultPath: vault.getPath(),
@@ -246,6 +257,7 @@ export async function getStatus(vaultPath: string): Promise<VaultStatus> {
       error: qmdError
     },
     graph: graphStatus,
+    observer: observerStaleness,
     git: gitStatus,
     links: {
       total: linkScan.linkCount,
@@ -308,6 +320,13 @@ export function formatStatus(status: VaultStatus): string {
   }
   if (status.graph.nodeCount !== undefined && status.graph.edgeCount !== undefined) {
     output += `  - Size: ${status.graph.nodeCount} nodes, ${status.graph.edgeCount} edges\n`;
+  }
+
+  output += '\nObserver:\n';
+  output += `  - Stale sessions: ${status.observer.staleCount}\n`;
+  if (status.observer.staleCount > 0) {
+    output += `  - Oldest stale age: ${formatAge(status.observer.oldestMs)}\n`;
+    output += `  - Newest stale age: ${formatAge(status.observer.newestMs)}\n`;
   }
 
   output += '\nLinks:\n';

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,6 +186,21 @@ export type { TransitionEvent } from './lib/transition-ledger.js';
 
 export { Observer } from './observer/observer.js';
 export type { ObserverOptions, ObserverCompressor, ObserverReflector } from './observer/observer.js';
+export {
+  observeActiveSessions,
+  getScaledObservationThresholdBytes,
+  parseSessionSourceLabel,
+  getObserverStaleness
+} from './observer/active-session-observer.js';
+export type {
+  ActiveObserveOptions,
+  ActiveObserveResult,
+  ActiveObservationCandidate,
+  ActiveObservationFailure,
+  ObserveCursorEntry,
+  ObserveCursorStore,
+  ObserverStalenessResult
+} from './observer/active-session-observer.js';
 export { Compressor } from './observer/compressor.js';
 export type { CompressorOptions, CompressionProvider } from './observer/compressor.js';
 export { Reflector } from './observer/reflector.js';

--- a/src/observer/active-session-observer.test.ts
+++ b/src/observer/active-session-observer.test.ts
@@ -4,12 +4,14 @@ import * as os from 'os';
 import * as path from 'path';
 import { listLedgerObservationFiles } from '../lib/ledger.js';
 import {
+  getObserverStaleness,
   getScaledObservationThresholdBytes,
   observeActiveSessions,
   parseSessionSourceLabel
 } from './active-session-observer.js';
 
 const originalNoLlm = process.env.CLAWVAULT_NO_LLM;
+const originalOpenClawStateDir = process.env.OPENCLAW_STATE_DIR;
 
 function makeTempDir(prefix: string): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -53,6 +55,7 @@ function messageLine(role: 'user' | 'assistant', text: string): string {
 
 afterEach(() => {
   process.env.CLAWVAULT_NO_LLM = originalNoLlm;
+  process.env.OPENCLAW_STATE_DIR = originalOpenClawStateDir;
 });
 
 describe('active-session-observer', () => {
@@ -152,6 +155,109 @@ describe('active-session-observer', () => {
 
       const cursorPath = path.join(vaultPath, '.clawvault', 'observe-cursors.json');
       expect(fs.existsSync(cursorPath)).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('continues observing remaining sessions when one session fails', async () => {
+    const root = makeTempDir('clawvault-active-observe-failures-');
+    const vaultPath = writeVault(root);
+    const sessionsDir = path.join(root, 'sessions');
+    fs.mkdirSync(sessionsDir, { recursive: true });
+
+    const sessionOk = 'session-ok';
+    const sessionFail = 'session-fail';
+    fs.writeFileSync(
+      path.join(sessionsDir, 'sessions.json'),
+      JSON.stringify({
+        'agent:clawdious:main': { sessionId: sessionOk, updatedAt: Date.now() },
+        'agent:clawdious:telegram:dm:123': { sessionId: sessionFail, updatedAt: Date.now() - 1 }
+      }),
+      'utf-8'
+    );
+    fs.writeFileSync(path.join(sessionsDir, `${sessionOk}.jsonl`), `${messageLine('user', 'Need migration plan')}\n`);
+    fs.writeFileSync(path.join(sessionsDir, `${sessionFail}.jsonl`), `${messageLine('assistant', 'Deploy patch')}\n`);
+
+    try {
+      const result = await observeActiveSessions(
+        {
+          vaultPath,
+          sessionsDir,
+          minNewBytes: 1
+        },
+        {
+          createObserver: () => ({
+            processMessages: async (_messages, options?: unknown): Promise<void> => {
+              const transcriptId = (options as { transcriptId?: string } | undefined)?.transcriptId;
+              if (transcriptId === sessionFail) {
+                throw new Error('Gemini timeout');
+              }
+            },
+            flush: async (): Promise<{ observations: string; routingSummary: string }> => ({
+              observations: '',
+              routingSummary: 'Routed 1 observations \u2192 decisions: 1'
+            })
+          })
+        }
+      );
+
+      expect(result.candidateSessions).toBe(2);
+      expect(result.observedSessions).toBe(1);
+      expect(result.cursorUpdates).toBe(1);
+      expect(result.failedSessionCount).toBe(1);
+      expect(result.failedSessions[0]?.sessionId).toBe(sessionFail);
+      expect(result.routedCounts.decisions).toBe(1);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reports stale observer cursors when session file has grown for over 12h', () => {
+    const root = makeTempDir('clawvault-observer-staleness-');
+    const vaultPath = writeVault(root);
+    const stateRoot = path.join(root, 'openclaw-state');
+    process.env.OPENCLAW_STATE_DIR = stateRoot;
+
+    const sessionsDir = path.join(stateRoot, 'agents', 'clawdious', 'sessions');
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    fs.writeFileSync(path.join(sessionsDir, 'stale-session.jsonl'), 'x'.repeat(120), 'utf-8');
+    fs.writeFileSync(path.join(sessionsDir, 'fresh-session.jsonl'), 'x'.repeat(80), 'utf-8');
+
+    const nowMs = Date.UTC(2026, 1, 15, 12, 0, 0);
+    const cursorPath = path.join(vaultPath, '.clawvault', 'observe-cursors.json');
+    fs.mkdirSync(path.dirname(cursorPath), { recursive: true });
+    fs.writeFileSync(
+      cursorPath,
+      JSON.stringify(
+        {
+          'stale-session': {
+            lastObservedOffset: 10,
+            lastObservedAt: new Date(nowMs - 13 * 60 * 60 * 1000).toISOString(),
+            sessionKey: 'agent:clawdious:main',
+            lastFileSize: 10
+          },
+          'fresh-session': {
+            lastObservedOffset: 80,
+            lastObservedAt: new Date(nowMs - 6 * 60 * 60 * 1000).toISOString(),
+            sessionKey: 'agent:clawdious:main',
+            lastFileSize: 70
+          }
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+
+    try {
+      const staleness = getObserverStaleness(vaultPath, {
+        now: () => new Date(nowMs)
+      });
+
+      expect(staleness.staleCount).toBe(1);
+      expect(staleness.oldestMs).toBe(13 * 60 * 60 * 1000);
+      expect(staleness.newestMs).toBe(13 * 60 * 60 * 1000);
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }

--- a/src/observer/active-session-observer.ts
+++ b/src/observer/active-session-observer.ts
@@ -12,6 +12,7 @@ const DEFAULT_AGENT_ID = 'clawdious';
 const AGENT_ID_RE = /^[a-zA-Z0-9_-]{1,100}$/;
 const SESSION_ID_RE = /^[a-zA-Z0-9._-]{1,200}$/;
 const CURSOR_FILE_NAME = 'observe-cursors.json';
+const STALE_CURSOR_THRESHOLD_MS = 12 * 60 * 60 * 1000;
 
 export interface ObserveCursorEntry {
   lastObservedOffset: number;
@@ -45,6 +46,13 @@ export interface ActiveObservationCandidate {
   thresholdBytes: number;
 }
 
+export interface ActiveObservationFailure {
+  sessionId: string;
+  sessionKey: string;
+  sourceLabel: string;
+  error: string;
+}
+
 export interface ActiveObserveResult {
   agentId: string;
   sessionsDir: string;
@@ -54,7 +62,17 @@ export interface ActiveObserveResult {
   cursorUpdates: number;
   dryRun: boolean;
   totalNewBytes: number;
+  observedNewBytes: number;
+  routedCounts: Record<string, number>;
+  failedSessionCount: number;
+  failedSessions: ActiveObservationFailure[];
   candidates: ActiveObservationCandidate[];
+}
+
+export interface ObserverStalenessResult {
+  staleCount: number;
+  oldestMs: number;
+  newestMs: number;
 }
 
 interface SessionDescriptor {
@@ -73,6 +91,11 @@ type ObserverFactory = (vaultPath: string, options: ObserverOptions) => MinimalO
 
 interface ActiveObserveDependencies {
   createObserver?: ObserverFactory;
+  now?: () => Date;
+}
+
+interface ObserverStalenessOptions {
+  sessionsDir?: string;
   now?: () => Date;
 }
 
@@ -161,6 +184,108 @@ export function saveObserveCursorStore(vaultPath: string, store: ObserveCursorSt
   const cursorPath = getCursorPath(vaultPath);
   fs.mkdirSync(path.dirname(cursorPath), { recursive: true });
   fs.writeFileSync(cursorPath, `${JSON.stringify(store, null, 2)}\n`, 'utf-8');
+}
+
+function parseAgentIdFromSessionKey(sessionKey: string): string | null {
+  const match = /^agent:([^:]+):/.exec(sessionKey);
+  if (!match?.[1]) {
+    return null;
+  }
+
+  const candidate = match[1].trim();
+  if (!AGENT_ID_RE.test(candidate)) {
+    return null;
+  }
+
+  return candidate;
+}
+
+function resolveSessionFileForCursor(
+  sessionId: string,
+  cursor: ObserveCursorEntry,
+  sessionsDirOverride?: string
+): string | null {
+  const candidates = new Set<string>();
+  if (sessionsDirOverride?.trim()) {
+    candidates.add(path.join(path.resolve(sessionsDirOverride.trim()), `${sessionId}.jsonl`));
+  }
+
+  const agentId = parseAgentIdFromSessionKey(cursor.sessionKey) ?? DEFAULT_AGENT_ID;
+  candidates.add(path.join(getSessionsDir(agentId), `${sessionId}.jsonl`));
+
+  for (const filePath of candidates) {
+    try {
+      const stat = fs.statSync(filePath);
+      if (stat.isFile()) {
+        return filePath;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+export function getObserverStaleness(
+  vaultPath: string,
+  options: ObserverStalenessOptions = {}
+): ObserverStalenessResult {
+  const nowDate = options.now ? options.now() : new Date();
+  const nowMs = nowDate.getTime();
+  if (!Number.isFinite(nowMs)) {
+    return {
+      staleCount: 0,
+      oldestMs: 0,
+      newestMs: 0
+    };
+  }
+
+  const cursorStore = loadObserveCursorStore(path.resolve(vaultPath));
+  let staleCount = 0;
+  let oldestMs = 0;
+  let newestMs = Number.POSITIVE_INFINITY;
+
+  for (const [sessionId, cursor] of Object.entries(cursorStore)) {
+    const observedAtMs = Date.parse(cursor.lastObservedAt);
+    if (!Number.isFinite(observedAtMs)) {
+      continue;
+    }
+
+    const ageMs = Math.max(0, nowMs - observedAtMs);
+    if (ageMs <= STALE_CURSOR_THRESHOLD_MS) {
+      continue;
+    }
+
+    const sessionFilePath = resolveSessionFileForCursor(sessionId, cursor, options.sessionsDir);
+    if (!sessionFilePath) {
+      continue;
+    }
+
+    let sessionStat: fs.Stats;
+    try {
+      sessionStat = fs.statSync(sessionFilePath);
+    } catch {
+      continue;
+    }
+    if (!sessionStat.isFile()) {
+      continue;
+    }
+
+    if (cursor.lastFileSize >= sessionStat.size) {
+      continue;
+    }
+
+    staleCount += 1;
+    oldestMs = Math.max(oldestMs, ageMs);
+    newestMs = Math.min(newestMs, ageMs);
+  }
+
+  return {
+    staleCount,
+    oldestMs: staleCount > 0 ? oldestMs : 0,
+    newestMs: staleCount > 0 ? newestMs : 0
+  };
 }
 
 function loadSessionIndex(sessionsDir: string): Record<string, SessionIndexEntry> {
@@ -405,6 +530,42 @@ function createDefaultObserver(vaultPath: string, options: ObserverOptions): Min
   return new Observer(vaultPath, options);
 }
 
+function parseRoutingCounts(routingSummary: string): Record<string, number> {
+  const counts: Record<string, number> = {};
+  const [, categorySection = ''] = routingSummary.split('\u2192');
+  const summaryCategories = categorySection.split('(')[0] ?? '';
+  if (!summaryCategories) {
+    return counts;
+  }
+
+  for (const match of summaryCategories.matchAll(/\b([a-z][a-z0-9-]*):\s*(\d+)\b/gi)) {
+    const category = match[1].toLowerCase();
+    const count = Number.parseInt(match[2], 10);
+    if (!Number.isFinite(count) || count <= 0) {
+      continue;
+    }
+    counts[category] = (counts[category] ?? 0) + count;
+  }
+
+  return counts;
+}
+
+function mergeRoutingCounts(
+  target: Record<string, number>,
+  incoming: Record<string, number>
+): void {
+  for (const [category, count] of Object.entries(incoming)) {
+    target[category] = (target[category] ?? 0) + count;
+  }
+}
+
+function stringifyError(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return String(error);
+}
+
 function selectCandidates(
   descriptors: SessionDescriptor[],
   cursors: ObserveCursorStore,
@@ -468,6 +629,10 @@ export async function observeActiveSessions(
       cursorUpdates: 0,
       dryRun,
       totalNewBytes: 0,
+      observedNewBytes: 0,
+      routedCounts: {},
+      failedSessionCount: 0,
+      failedSessions: [],
       candidates: []
     };
   }
@@ -487,43 +652,66 @@ export async function observeActiveSessions(
       cursorUpdates: 0,
       dryRun,
       totalNewBytes: candidates.reduce((sum, candidate) => sum + candidate.newBytes, 0),
+      observedNewBytes: 0,
+      routedCounts: {},
+      failedSessionCount: 0,
+      failedSessions: [],
       candidates
     };
   }
 
   const observerFactory = dependencies.createObserver ?? createDefaultObserver;
-  const observer = observerFactory(vaultPath, {
+  const observerOptions: ObserverOptions = {
     tokenThreshold: options.threshold,
     reflectThreshold: options.reflectThreshold,
     model: options.model,
     extractTasks: options.extractTasks
-  });
+  };
 
   let observedSessions = 0;
   let cursorUpdates = 0;
+  let observedNewBytes = 0;
+  const routedCounts: Record<string, number> = {};
+  const failedSessions: ActiveObservationFailure[] = [];
 
   for (const candidate of candidates) {
-    const { messages, nextOffset } = await readIncrementalMessages(candidate.filePath, candidate.startOffset);
-    const taggedMessages = messages.map((message) => `[${candidate.sourceLabel}] ${message}`);
+    try {
+      const observer = observerFactory(vaultPath, observerOptions);
+      const { messages, nextOffset } = await readIncrementalMessages(candidate.filePath, candidate.startOffset);
+      const taggedMessages = messages.map((message) => `[${candidate.sourceLabel}] ${message}`);
 
-    if (taggedMessages.length > 0) {
-      await observer.processMessages(taggedMessages, {
-        source: 'openclaw',
+      if (taggedMessages.length > 0) {
+        await observer.processMessages(taggedMessages, {
+          source: 'openclaw',
+          sessionKey: candidate.sessionKey,
+          transcriptId: candidate.sessionId
+        });
+        const flushResult = await observer.flush();
+        mergeRoutingCounts(routedCounts, parseRoutingCounts(flushResult.routingSummary));
+        observedSessions += 1;
+        observedNewBytes += candidate.newBytes;
+      }
+
+      if (nextOffset > candidate.startOffset) {
+        cursors[candidate.sessionId] = {
+          lastObservedOffset: nextOffset,
+          lastObservedAt: now().toISOString(),
+          sessionKey: candidate.sessionKey,
+          lastFileSize: candidate.fileSize
+        };
+        cursorUpdates += 1;
+      }
+    } catch (error) {
+      const reason = stringifyError(error);
+      failedSessions.push({
+        sessionId: candidate.sessionId,
         sessionKey: candidate.sessionKey,
-        transcriptId: candidate.sessionId
+        sourceLabel: candidate.sourceLabel,
+        error: reason
       });
-      await observer.flush();
-      observedSessions += 1;
-    }
-
-    if (nextOffset > candidate.startOffset) {
-      cursors[candidate.sessionId] = {
-        lastObservedOffset: nextOffset,
-        lastObservedAt: now().toISOString(),
-        sessionKey: candidate.sessionKey,
-        lastFileSize: candidate.fileSize
-      };
-      cursorUpdates += 1;
+      console.error(
+        `[observer] failed to observe session ${candidate.sessionKey} (${candidate.sessionId}): ${reason}`
+      );
     }
   }
 
@@ -540,6 +728,10 @@ export async function observeActiveSessions(
     cursorUpdates,
     dryRun,
     totalNewBytes: candidates.reduce((sum, candidate) => sum + candidate.newBytes, 0),
+    observedNewBytes,
+    routedCounts,
+    failedSessionCount: failedSessions.length,
+    failedSessions,
     candidates
   };
 }

--- a/src/observer/router.test.ts
+++ b/src/observer/router.test.ts
@@ -228,6 +228,50 @@ describe('Router', () => {
     }
   });
 
+  it('skips past-tense completed task candidates without future intent', () => {
+    const vaultPath = makeTempVault();
+    const router = new Router(vaultPath);
+
+    const markdown = [
+      '## 2026-02-11',
+      '',
+      '- [task|c=0.84|i=0.70] 10:00 Completed deployment runbook and merged the release PR'
+    ].join('\n');
+
+    try {
+      const { routed, summary } = router.route(markdown, { sessionKey: 'agent:clawdious:main' });
+      const backlogItems = routed.filter((item) => item.category === 'backlog');
+      expect(backlogItems).toHaveLength(0);
+      expect(summary).toBe('No items routed to vault categories.');
+      expect(fs.existsSync(path.join(vaultPath, 'backlog'))).toBe(false);
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps past-tense task candidates when future intent is present', () => {
+    const vaultPath = makeTempVault();
+    const router = new Router(vaultPath);
+
+    const markdown = [
+      '## 2026-02-11',
+      '',
+      '- [task|c=0.84|i=0.70] 10:00 Fixed auth fallback and need to add integration tests'
+    ].join('\n');
+
+    try {
+      const { routed } = router.route(markdown, { sessionKey: 'agent:clawdious:main' });
+      const backlogItems = routed.filter((item) => item.category === 'backlog');
+      expect(backlogItems).toHaveLength(1);
+      const backlogDir = path.join(vaultPath, 'backlog');
+      expect(fs.existsSync(backlogDir)).toBe(true);
+      const entries = fs.readdirSync(backlogDir).filter((entry) => entry.endsWith('.md'));
+      expect(entries).toHaveLength(1);
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+    }
+  });
+
   it('deduplicates repeated task observations into a single backlog item', () => {
     const vaultPath = makeTempVault();
     const router = new Router(vaultPath);

--- a/src/observer/router.ts
+++ b/src/observer/router.ts
@@ -130,6 +130,9 @@ const TYPE_TO_CATEGORY: Record<ObservationType, string> = {
   project: 'projects'
 };
 
+const PAST_TENSE_TASK_HINT_RE = /\b(completed|shipped|deployed|fixed|merged|finished|resolved|closed)\b/i;
+const FUTURE_TASK_HINT_RE = /\b(need to|should|todo|must|plan to)\b/i;
+
 export class Router {
   private readonly vaultPath: string;
   private readonly extractTasks: boolean;
@@ -211,6 +214,11 @@ export class Router {
     context: RouteContext,
     knownWorkItems: ExistingWorkItem[]
   ): { routedItem: RoutedItem | null; dedupHit: boolean } {
+    if (this.shouldSkipCompletedTaskCandidate(item.content)) {
+      console.log('[observer] skipped likely-completed task candidate');
+      return { routedItem: null, dedupHit: false };
+    }
+
     const title = this.deriveTaskTitle(item.content, item.type);
     if (!title) {
       return { routedItem: null, dedupHit: false };
@@ -366,6 +374,13 @@ export class Router {
       .trim();
 
     return title.slice(0, 120);
+  }
+
+  private shouldSkipCompletedTaskCandidate(content: string): boolean {
+    if (!PAST_TENSE_TASK_HINT_RE.test(content)) {
+      return false;
+    }
+    return !FUTURE_TASK_HINT_RE.test(content);
   }
 
   private buildTaskContextContent(


### PR DESCRIPTION
Adds a `--cron` mode for reliable, cron-friendly observation, improves error resilience, adds staleness detection, and reduces task extraction false positives.

The original observer ran once and exited, leading to silent failures if cron jobs failed. This PR addresses that by providing a robust `--cron` mode with clear output, per-session error handling, and staleness detection for proactive monitoring. It also refines task extraction to reduce noise.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-5de8e2e3-278d-48eb-aa08-35eef2f59fe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5de8e2e3-278d-48eb-aa08-35eef2f59fe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

