### PR TITLE
Memory status index counts

### DIFF
--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -134,7 +134,7 @@ describe('status command', () => {
     hasQmdMock.mockReturnValue(true);
     execFileSyncMock.mockImplementation((command: string) => {
       if (command === 'qmd') {
-        return `Collections (1):\n\n${mockCollection} (qmd://${mockCollection}/)\n  Pattern: **/*.md\n  Root: ${mockRoot}\n`;
+        return `Collections (1):\n\n${mockCollection} (qmd://${mockCollection}/)\n  Pattern: **/*.md\n  Root: ${mockRoot}\n  Files: 168\n  Vectors: 324\n`;
       }
       if (command === 'git') {
         return '';
@@ -176,6 +176,8 @@ describe('status command', () => {
       expect(status.issues).toHaveLength(0);
       expect(status.checkpoint.exists).toBe(true);
       expect(status.qmd.indexStatus).toBe('present');
+      expect(status.qmd.files).toBe(168);
+      expect(status.qmd.vectors).toBe(324);
       expect(status.links.total).toBe(0);
       expect(status.links.orphans).toBe(0);
       expect(status.graph.indexStatus).toBe('present');
@@ -184,6 +186,8 @@ describe('status command', () => {
       expect(formatted).toContain('Graph:');
       expect(formatted).toContain('Observer:');
       expect(formatted).toContain('Links:');
+      expect(formatted).toContain('Files: 168');
+      expect(formatted).toContain('Vectors: 324');
     } finally {
       fs.rmSync(vaultPath, { recursive: true, force: true });
     }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -7,6 +7,7 @@ import { formatAge } from '../lib/time.js';
 import { scanVaultLinks } from '../lib/backlinks.js';
 import { loadMemoryGraphIndex } from '../lib/memory-graph.js';
 import { getObserverStaleness } from '../observer/active-session-observer.js';
+import { parseQmdCollectionList } from '../lib/qmd-collections.js';
 import type { CheckpointData } from './checkpoint.js';
 
 export interface VaultStatus {
@@ -26,6 +27,8 @@ export interface VaultStatus {
     collection: string;
     root: string;
     indexStatus: 'present' | 'missing' | 'root-mismatch';
+    files?: number;
+    vectors?: number;
     error?: string;
   };
   graph: {
@@ -125,16 +128,26 @@ function parseQmdCollectionsText(raw: string): string[] {
   return names;
 }
 
-function getQmdIndexStatus(collection: string, root: string, indexName?: string): 'present' | 'missing' | 'root-mismatch' {
-  // qmd collection list doesn't support --json, parse text output instead
+interface QmdIndexResult {
+  status: 'present' | 'missing' | 'root-mismatch';
+  files?: number;
+  vectors?: number;
+}
+
+function getQmdIndexStatus(collection: string, root: string, indexName?: string): QmdIndexResult {
   const output = execFileSync('qmd', withQmdIndexArgs(['collection', 'list'], indexName), { encoding: 'utf-8' });
-  const names = parseQmdCollectionsText(output);
+  const collections = parseQmdCollectionList(output);
   
-  if (names.includes(collection)) {
-    return 'present';
+  const collectionInfo = collections.find(c => c.name === collection);
+  if (collectionInfo) {
+    return {
+      status: 'present',
+      files: collectionInfo.files,
+      vectors: collectionInfo.vectors
+    };
   }
 
-  return 'missing';
+  return { status: 'missing' };
 }
 
 function loadCheckpoint(vaultPath: string): { data: CheckpointData | null; error?: string } {
@@ -193,12 +206,12 @@ export async function getStatus(
 
   const qmdCollection = vault.getQmdCollection();
   const qmdRoot = vault.getQmdRoot();
-  let qmdIndexStatus: VaultStatus['qmd']['indexStatus'] = 'missing';
+  let qmdIndexResult: QmdIndexResult = { status: 'missing' };
   let qmdError: string | undefined;
   try {
-    qmdIndexStatus = getQmdIndexStatus(qmdCollection, qmdRoot, options.qmdIndexName);
-    if (qmdIndexStatus !== 'present') {
-      issues.push(`qmd collection ${qmdIndexStatus.replace('-', ' ')}`);
+    qmdIndexResult = getQmdIndexStatus(qmdCollection, qmdRoot, options.qmdIndexName);
+    if (qmdIndexResult.status !== 'present') {
+      issues.push(`qmd collection ${qmdIndexResult.status.replace('-', ' ')}`);
     }
   } catch (err: any) {
     qmdError = err?.message || 'Failed to check qmd index';
@@ -256,7 +269,9 @@ export async function getStatus(
     qmd: {
       collection: qmdCollection,
       root: qmdRoot,
-      indexStatus: qmdIndexStatus,
+      indexStatus: qmdIndexResult.status,
+      files: qmdIndexResult.files,
+      vectors: qmdIndexResult.vectors,
       error: qmdError
     },
     graph: graphStatus,
@@ -306,6 +321,12 @@ export function formatStatus(status: VaultStatus): string {
   output += `  - Collection: ${status.qmd.collection}\n`;
   output += `  - Root: ${status.qmd.root}\n`;
   output += `  - Index: ${status.qmd.indexStatus}\n`;
+  if (status.qmd.files !== undefined) {
+    output += `  - Files: ${status.qmd.files}\n`;
+  }
+  if (status.qmd.vectors !== undefined) {
+    output += `  - Vectors: ${status.qmd.vectors}\n`;
+  }
   if (status.qmd.error) {
     output += `  - Error: ${status.qmd.error}\n`;
   }


### PR DESCRIPTION
Fixes GitHub issue #77 by updating the `clawvault status` command to accurately display indexed file and chunk counts.

The previous status display incorrectly reported "Indexed: 0/0 files and 0 chunks" because the `VaultStatus` interface and related functions (`getQmdIndexStatus`, `formatStatus`) were not utilizing the file and vector counts already available from the `qmd collection list` output. This PR integrates these counts into the status display.

---
<p><a href="https://cursor.com/agents?id=bc-0859b505-21c5-45dd-a02f-fc92c13b04ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0859b505-21c5-45dd-a02f-fc92c13b04ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

