### PR TITLE
ClawVault migration and errors

### DIFF
--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -3,10 +3,11 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-const { hasQmdMock, scanVaultLinksMock, getObserverStalenessMock } = vi.hoisted(() => ({
+const { hasQmdMock, scanVaultLinksMock, getObserverStalenessMock, listQmdCollectionsMock } = vi.hoisted(() => ({
   hasQmdMock: vi.fn(),
   scanVaultLinksMock: vi.fn(),
-  getObserverStalenessMock: vi.fn()
+  getObserverStalenessMock: vi.fn(),
+  listQmdCollectionsMock: vi.fn()
 }));
 
 let mockStats = { documents: 0, categories: {} as Record<string, number> };
@@ -40,6 +41,14 @@ vi.mock('../observer/active-session-observer.js', () => ({
   getObserverStaleness: getObserverStalenessMock
 }));
 
+vi.mock('../lib/qmd-collections.js', () => ({
+  listQmdCollections: listQmdCollectionsMock,
+  removeQmdCollection: vi.fn()
+}));
+
+let mockQmdCollection = 'vault';
+let mockQmdRoot = '/tmp/vault';
+
 vi.mock('../lib/vault.js', () => ({
   ClawVault: class {
     private vaultPath: string;
@@ -68,7 +77,11 @@ vi.mock('../lib/vault.js', () => ({
     }
 
     getQmdCollection(): string {
-      return 'vault';
+      return mockQmdCollection;
+    }
+
+    getQmdRoot(): string {
+      return mockQmdRoot;
     }
   },
   findVault: async () => null
@@ -111,6 +124,9 @@ beforeEach(() => {
     oldestMs: 0,
     newestMs: 0
   });
+  listQmdCollectionsMock.mockReturnValue([]);
+  mockQmdCollection = 'vault';
+  mockQmdRoot = '/tmp/vault';
 });
 
 describe('doctor', () => {
@@ -197,5 +213,128 @@ describe('doctor', () => {
       fs.rmSync(vaultPath, { recursive: true, force: true });
       fs.rmSync(homePath, { recursive: true, force: true });
     }
+  });
+
+  it('detects missing qmd collection as migration issue', async () => {
+    hasQmdMock.mockReturnValue(true);
+    listQmdCollectionsMock.mockReturnValue([]);
+    scanVaultLinksMock.mockReturnValue({
+      backlinks: new Map(),
+      orphans: [],
+      linkCount: 0
+    });
+
+    const vaultPath = makeTempDir('clawvault-doctor-migration-');
+    const homePath = makeTempDir('clawvault-home-migration-');
+    process.env.HOME = homePath;
+    process.env.SHELL = '/bin/bash';
+    fs.writeFileSync(path.join(homePath, '.bashrc'), 'export CLAWVAULT_PATH="/tmp/vault"');
+
+    mockStats = { documents: 10, categories: {} };
+    mockDocuments = [makeDoc('projects', new Date())];
+    mockHandoffs = [makeDoc('handoffs', new Date())];
+    mockInbox = [];
+    mockQmdCollection = 'my-vault';
+    mockQmdRoot = vaultPath;
+
+    try {
+      const report = await doctor(vaultPath);
+      expect(report.migrationIssues.length).toBeGreaterThan(0);
+      const missingCollection = report.migrationIssues.find(
+        issue => issue.type === 'missing_qmd_collection'
+      );
+      expect(missingCollection).toBeDefined();
+      expect(missingCollection?.autoFixable).toBe(true);
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+      fs.rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it('detects stale v2 collection name as migration issue', async () => {
+    hasQmdMock.mockReturnValue(true);
+    const vaultPath = makeTempDir('clawvault-doctor-stale-');
+    listQmdCollectionsMock.mockReturnValue([
+      { name: 'clawvault', uri: 'qmd://clawvault', root: vaultPath, details: {} }
+    ]);
+    scanVaultLinksMock.mockReturnValue({
+      backlinks: new Map(),
+      orphans: [],
+      linkCount: 0
+    });
+
+    const homePath = makeTempDir('clawvault-home-stale-');
+    process.env.HOME = homePath;
+    process.env.SHELL = '/bin/bash';
+    fs.writeFileSync(path.join(homePath, '.bashrc'), 'export CLAWVAULT_PATH="/tmp/vault"');
+
+    mockStats = { documents: 10, categories: {} };
+    mockDocuments = [makeDoc('projects', new Date())];
+    mockHandoffs = [makeDoc('handoffs', new Date())];
+    mockInbox = [];
+    mockQmdCollection = 'my-new-vault';
+    mockQmdRoot = vaultPath;
+
+    try {
+      const report = await doctor(vaultPath);
+      const staleCollection = report.migrationIssues.find(
+        issue => issue.type === 'stale_collection_name'
+      );
+      expect(staleCollection).toBeDefined();
+      expect(staleCollection?.autoFixable).toBe(true);
+      expect(staleCollection?.details).toMatchObject({
+        oldName: 'clawvault',
+        newName: 'my-new-vault'
+      });
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+      fs.rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it('detects wrong vault path as migration issue', async () => {
+    hasQmdMock.mockReturnValue(true);
+    const vaultPath = makeTempDir('clawvault-doctor-wrongpath-');
+    const wrongPath = '/some/other/path';
+    listQmdCollectionsMock.mockReturnValue([
+      { name: 'my-vault', uri: 'qmd://my-vault', root: wrongPath, details: {} }
+    ]);
+    scanVaultLinksMock.mockReturnValue({
+      backlinks: new Map(),
+      orphans: [],
+      linkCount: 0
+    });
+
+    const homePath = makeTempDir('clawvault-home-wrongpath-');
+    process.env.HOME = homePath;
+    process.env.SHELL = '/bin/bash';
+    fs.writeFileSync(path.join(homePath, '.bashrc'), 'export CLAWVAULT_PATH="/tmp/vault"');
+
+    mockStats = { documents: 10, categories: {} };
+    mockDocuments = [makeDoc('projects', new Date())];
+    mockHandoffs = [makeDoc('handoffs', new Date())];
+    mockInbox = [];
+    mockQmdCollection = 'my-vault';
+    mockQmdRoot = vaultPath;
+
+    try {
+      const report = await doctor(vaultPath);
+      const wrongPathIssue = report.migrationIssues.find(
+        issue => issue.type === 'wrong_vault_path'
+      );
+      expect(wrongPathIssue).toBeDefined();
+      expect(wrongPathIssue?.autoFixable).toBe(true);
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+      fs.rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it('includes actionable hint for qmd not installed', async () => {
+    hasQmdMock.mockReturnValue(false);
+    const report = await doctor('/tmp/vault');
+    const qmdCheck = report.checks.find(check => check.label === 'qmd installed');
+    expect(qmdCheck?.hint).toContain('bun install');
+    expect(qmdCheck?.hint).toContain('github.com/tobi/qmd');
   });
 });

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -4,10 +4,12 @@ import * as path from 'path';
 import { ClawVault, findVault } from '../lib/vault.js';
 import { scanVaultLinks } from '../lib/backlinks.js';
 import { formatAge } from '../lib/time.js';
-import { hasQmd } from '../lib/search.js';
+import { hasQmd, QMD_INSTALL_COMMAND, QMD_INSTALL_URL } from '../lib/search.js';
 import { loadMemoryGraphIndex } from '../lib/memory-graph.js';
 import { getObserverStaleness } from '../observer/active-session-observer.js';
 import { checkOpenClawCompatibility } from './compat.js';
+import { listQmdCollections, type QmdCollectionInfo } from '../lib/qmd-collections.js';
+import { loadVaultQmdConfig } from '../lib/vault-qmd-config.js';
 
 const CLAWVAULT_DIR = '.clawvault';
 const CHECKPOINT_FILE = 'last-checkpoint.json';
@@ -21,6 +23,7 @@ export interface DoctorCheck {
   status: DoctorStatus;
   detail?: string;
   hint?: string;
+  category?: 'system' | 'migration' | 'health';
 }
 
 export interface DoctorReport {
@@ -28,7 +31,30 @@ export interface DoctorReport {
   checks: DoctorCheck[];
   warnings: number;
   errors: number;
+  migrationIssues: MigrationIssue[];
 }
+
+export interface MigrationIssue {
+  type: MigrationIssueType;
+  description: string;
+  autoFixable: boolean;
+  details?: Record<string, unknown>;
+}
+
+export type MigrationIssueType =
+  | 'stale_collection_name'
+  | 'missing_qmd_collection'
+  | 'wrong_vault_path'
+  | 'orphaned_collection'
+  | 'missing_qmd_config'
+  | 'legacy_config_format';
+
+const V2_COLLECTION_PATTERNS = [
+  /^clawvault$/i,
+  /^vault$/i,
+  /^memory$/i,
+  /^notes$/i
+];
 
 function daysSince(date: Date, now: number = Date.now()): number {
   return Math.max(0, Math.floor((now - date.getTime()) / DAY_MS));
@@ -78,6 +104,153 @@ function hasClawvaultPathConfig(paths: string[]): boolean {
   return false;
 }
 
+function isLikelyV2CollectionName(name: string): boolean {
+  return V2_COLLECTION_PATTERNS.some(pattern => pattern.test(name));
+}
+
+function checkQmdCollectionExists(
+  collections: QmdCollectionInfo[],
+  expectedName: string
+): { exists: boolean; collection?: QmdCollectionInfo } {
+  const found = collections.find(c => c.name === expectedName);
+  return { exists: !!found, collection: found };
+}
+
+function checkCollectionPathMatches(
+  collection: QmdCollectionInfo,
+  expectedRoot: string
+): boolean {
+  if (!collection.root) return false;
+  const normalizedCollectionRoot = path.resolve(collection.root);
+  const normalizedExpectedRoot = path.resolve(expectedRoot);
+  return normalizedCollectionRoot === normalizedExpectedRoot;
+}
+
+function detectMigrationIssues(
+  vaultPath: string,
+  configuredCollection: string | undefined,
+  configuredRoot: string | undefined
+): MigrationIssue[] {
+  const issues: MigrationIssue[] = [];
+  
+  if (!hasQmd()) {
+    return issues;
+  }
+
+  let collections: QmdCollectionInfo[];
+  try {
+    collections = listQmdCollections();
+  } catch {
+    return issues;
+  }
+
+  const vaultConfig = loadVaultQmdConfig(vaultPath);
+  const expectedCollection = configuredCollection || vaultConfig.qmdCollection;
+  const expectedRoot = configuredRoot || vaultConfig.qmdRoot;
+
+  const { exists, collection } = checkQmdCollectionExists(collections, expectedCollection);
+
+  if (!exists) {
+    const potentialV2Collections = collections.filter(c => 
+      isLikelyV2CollectionName(c.name) && 
+      c.root && 
+      path.resolve(c.root) === path.resolve(expectedRoot)
+    );
+
+    if (potentialV2Collections.length > 0) {
+      issues.push({
+        type: 'stale_collection_name',
+        description: `Found v2-style collection "${potentialV2Collections[0].name}" that should be renamed to "${expectedCollection}"`,
+        autoFixable: true,
+        details: {
+          oldName: potentialV2Collections[0].name,
+          newName: expectedCollection,
+          root: potentialV2Collections[0].root
+        }
+      });
+    } else {
+      issues.push({
+        type: 'missing_qmd_collection',
+        description: `qmd collection "${expectedCollection}" does not exist`,
+        autoFixable: true,
+        details: {
+          collectionName: expectedCollection,
+          expectedRoot
+        }
+      });
+    }
+  } else if (collection && !checkCollectionPathMatches(collection, expectedRoot)) {
+    issues.push({
+      type: 'wrong_vault_path',
+      description: `Collection "${expectedCollection}" points to "${collection.root}" but vault is at "${expectedRoot}"`,
+      autoFixable: true,
+      details: {
+        collectionName: expectedCollection,
+        currentRoot: collection.root,
+        expectedRoot
+      }
+    });
+  }
+
+  const orphanedCollections = collections.filter(c => {
+    if (c.name === expectedCollection) return false;
+    if (!c.root) return false;
+    const collectionRoot = path.resolve(c.root);
+    const vaultRoot = path.resolve(expectedRoot);
+    return collectionRoot === vaultRoot || collectionRoot.startsWith(vaultRoot + path.sep);
+  });
+
+  for (const orphan of orphanedCollections) {
+    issues.push({
+      type: 'orphaned_collection',
+      description: `Orphaned collection "${orphan.name}" points to vault path but is not the configured collection`,
+      autoFixable: true,
+      details: {
+        collectionName: orphan.name,
+        root: orphan.root
+      }
+    });
+  }
+
+  const configPath = path.join(vaultPath, '.clawvault.json');
+  if (fs.existsSync(configPath)) {
+    try {
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      if (!config.qmdCollection || !config.qmdRoot) {
+        issues.push({
+          type: 'missing_qmd_config',
+          description: 'Vault config is missing qmdCollection or qmdRoot settings',
+          autoFixable: true,
+          details: {
+            hasQmdCollection: !!config.qmdCollection,
+            hasQmdRoot: !!config.qmdRoot
+          }
+        });
+      }
+    } catch {
+      issues.push({
+        type: 'legacy_config_format',
+        description: 'Unable to parse .clawvault.json - may need migration',
+        autoFixable: false
+      });
+    }
+  }
+
+  return issues;
+}
+
+function migrationIssuesToChecks(issues: MigrationIssue[]): DoctorCheck[] {
+  return issues.map(issue => ({
+    label: `migration: ${issue.type.replace(/_/g, ' ')}`,
+    status: 'warn' as DoctorStatus,
+    detail: issue.description,
+    hint: issue.autoFixable 
+      ? 'Run `clawvault migrate` to auto-fix this issue.'
+      : 'Manual intervention required.',
+    category: 'migration' as const
+  }));
+}
+
 async function resolveVault(vaultPath?: string): Promise<ClawVault> {
   if (vaultPath) {
     const vault = new ClawVault(path.resolve(vaultPath));
@@ -103,6 +276,7 @@ export async function doctor(vaultPath?: string): Promise<DoctorReport> {
   const checks: DoctorCheck[] = [];
   let warnings = 0;
   let errors = 0;
+  const migrationIssues: MigrationIssue[] = [];
   const compatReport = checkOpenClawCompatibility();
 
   if (compatReport.errors > 0) {
@@ -110,7 +284,8 @@ export async function doctor(vaultPath?: string): Promise<DoctorReport> {
       label: 'OpenClaw compatibility',
       status: 'error',
       detail: `${compatReport.errors} error(s), ${compatReport.warnings} warning(s)`,
-      hint: 'Run `clawvault compat` for full compatibility diagnostics.'
+      hint: 'Run `clawvault compat` for full compatibility diagnostics.',
+      category: 'system'
     });
     errors++;
   } else if (compatReport.warnings > 0) {
@@ -118,23 +293,27 @@ export async function doctor(vaultPath?: string): Promise<DoctorReport> {
       label: 'OpenClaw compatibility',
       status: 'warn',
       detail: `${compatReport.warnings} warning(s)`,
-      hint: 'Run `clawvault compat` for full compatibility diagnostics.'
+      hint: 'Run `clawvault compat` for full compatibility diagnostics.',
+      category: 'system'
     });
     warnings++;
   } else {
     checks.push({
       label: 'OpenClaw compatibility',
-      status: 'ok'
+      status: 'ok',
+      category: 'system'
     });
   }
 
   if (hasQmd()) {
-    checks.push({ label: 'qmd installed', status: 'ok' });
+    checks.push({ label: 'qmd installed', status: 'ok', category: 'system' });
   } else {
     checks.push({
       label: 'qmd installed',
       status: 'error',
-      hint: 'Install qmd to enable ClawVault commands.'
+      detail: 'qmd binary not found in PATH',
+      hint: `Install qmd to enable ClawVault search and indexing:\n  ${QMD_INSTALL_COMMAND}\n\nFor more information: ${QMD_INSTALL_URL}`,
+      category: 'system'
     });
     errors++;
   }
@@ -144,34 +323,48 @@ export async function doctor(vaultPath?: string): Promise<DoctorReport> {
     checks.push({
       label: 'CLAWVAULT_PATH in shell config',
       status: 'ok',
-      detail: shellConfigs.map(p => path.basename(p)).join(', ')
+      detail: shellConfigs.map(p => path.basename(p)).join(', '),
+      category: 'system'
     });
   } else {
     checks.push({
       label: 'CLAWVAULT_PATH in shell config',
       status: 'warn',
-      hint: 'Run `clawvault shell-init` and add it to your shell rc.'
+      hint: 'Run `clawvault shell-init` and add it to your shell rc.',
+      category: 'system'
     });
     warnings++;
   }
 
   if (!hasQmd()) {
-    return { vaultPath, checks, warnings, errors };
+    return { vaultPath, checks, warnings, errors, migrationIssues };
   }
 
   let vault: ClawVault;
   try {
     vault = await resolveVault(vaultPath);
-    checks.push({ label: 'vault found', status: 'ok', detail: vault.getPath() });
+    checks.push({ label: 'vault found', status: 'ok', detail: vault.getPath(), category: 'system' });
   } catch (err: any) {
     checks.push({
       label: 'vault found',
       status: 'error',
-      detail: err?.message || 'Unable to locate vault'
+      detail: err?.message || 'Unable to locate vault',
+      category: 'system'
     });
     errors++;
-    return { vaultPath, checks, warnings, errors };
+    return { vaultPath, checks, warnings, errors, migrationIssues };
   }
+
+  const detectedMigrationIssues = detectMigrationIssues(
+    vault.getPath(),
+    vault.getQmdCollection(),
+    vault.getQmdRoot()
+  );
+  migrationIssues.push(...detectedMigrationIssues);
+  
+  const migrationChecks = migrationIssuesToChecks(detectedMigrationIssues);
+  checks.push(...migrationChecks);
+  warnings += migrationChecks.length;
 
   const stats = await vault.stats();
   const documents = await vault.list();
@@ -180,12 +373,13 @@ export async function doctor(vaultPath?: string): Promise<DoctorReport> {
   const qmdCollection = vault.getQmdCollection();
 
   if (qmdCollection) {
-    checks.push({ label: 'qmd collection configured', status: 'ok', detail: qmdCollection });
+    checks.push({ label: 'qmd collection configured', status: 'ok', detail: qmdCollection, category: 'system' });
   } else {
     checks.push({
       label: 'qmd collection configured',
       status: 'warn',
-      hint: 'Set qmd collection in .clawvault.json'
+      hint: 'Set qmd collection in .clawvault.json or run `clawvault migrate`.',
+      category: 'system'
     });
     warnings++;
   }
@@ -201,7 +395,8 @@ export async function doctor(vaultPath?: string): Promise<DoctorReport> {
       label: 'memory graph index',
       status: 'warn',
       detail: 'No graph index found',
-      hint: 'Run `clawvault graph --refresh` to build .clawvault/graph-index.json.'
+      hint: 'Run `clawvault graph --refresh` to build .clawvault/graph-index.json.',
+      category: 'health'
     });
     warnings++;
   } else {
@@ -215,14 +410,16 @@ export async function doctor(vaultPath?: string): Promise<DoctorReport> {
         label: 'memory graph index',
         status: 'warn',
         detail: `Stale graph index (generated ${generatedAge} ago)`,
-        hint: 'Run `clawvault graph --refresh` to resync index.'
+        hint: 'Run `clawvault graph --refresh` to resync index.',
+        category: 'health'
       });
       warnings++;
     } else {
       checks.push({
         label: 'memory graph index',
         status: 'ok',
-        detail: `${graphIndex.graph.stats.nodeCount} nodes, ${graphIndex.graph.stats.edgeCount} edges`
+        detail: `${graphIndex.graph.stats.nodeCount} nodes, ${graphIndex.graph.stats.edgeCount} edges`,
+        category: 'health'
       });
     }
   }
@@ -232,7 +429,8 @@ export async function doctor(vaultPath?: string): Promise<DoctorReport> {
     checks.push({
       label: 'recent handoff',
       status: 'warn',
-      hint: 'Run `clawvault sleep` at the end of sessions.'
+      hint: 'Run `clawvault sleep` at the end of sessions.',
+      category: 'health'
     });
     warnings++;
   } else {
@@ -246,14 +444,16 @@ export async function doctor(vaultPath?: string): Promise<DoctorReport> {
         label: 'recent handoff',
         status: 'warn',
         detail: `Last handoff ${ageLabel} ago`,
-        hint: 'Run `clawvault sleep` before long pauses.'
+        hint: 'Run `clawvault sleep` before long pauses.',
+        category: 'health'
       });
       warnings++;
     } else {
       checks.push({
         label: 'recent handoff',
         status: 'ok',
-        detail: `Last handoff ${ageLabel} ago`
+        detail: `Last handoff ${ageLabel} ago`,
+        category: 'health'
       });
     }
   }
@@ -267,7 +467,8 @@ export async function doctor(vaultPath?: string): Promise<DoctorReport> {
     checks.push({
       label: 'checkpoint freshness',
       status: 'warn',
-      detail: checkpointInfo.error
+      detail: checkpointInfo.error,
+      category: 'health'
     });
     warnings++;
   } else if (!checkpointInfo.timestamp) {
@@ -277,7 +478,8 @@ export async function doctor(vaultPath?: string): Promise<DoctorReport> {
       label: 'checkpoint freshness',
       status,
       detail: activeUse ? 'No checkpoint found' : 'No checkpoint found (vault appears inactive)',
-      hint: activeUse ? 'Run `clawvault checkpoint` during heavy work.' : undefined
+      hint: activeUse ? 'Run `clawvault checkpoint` during heavy work.' : undefined,
+      category: 'health'
     });
   } else {
     const checkpointDate = new Date(checkpointInfo.timestamp);
@@ -288,14 +490,16 @@ export async function doctor(vaultPath?: string): Promise<DoctorReport> {
         label: 'checkpoint freshness',
         status: 'warn',
         detail: `Last checkpoint ${ageLabel} ago`,
-        hint: 'Checkpoint at least once per active day.'
+        hint: 'Checkpoint at least once per active day.',
+        category: 'health'
       });
       warnings++;
     } else {
       checks.push({
         label: 'checkpoint freshness',
         status: 'ok',
-        detail: `Last checkpoint ${ageLabel} ago`
+        detail: `Last checkpoint ${ageLabel} ago`,
+        category: 'health'
       });
     }
   }
@@ -306,13 +510,15 @@ export async function doctor(vaultPath?: string): Promise<DoctorReport> {
       label: 'observer freshness',
       status: 'warn',
       detail: `${observerStaleness.staleCount} stale session cursor(s); oldest ${formatAge(observerStaleness.oldestMs)} ago`,
-      hint: 'Run `clawvault observe --cron` and verify cron/hook scheduling.'
+      hint: 'Run `clawvault observe --cron` and verify cron/hook scheduling.',
+      category: 'health'
     });
     warnings++;
   } else {
     checks.push({
       label: 'observer freshness',
-      status: 'ok'
+      status: 'ok',
+      category: 'health'
     });
   }
 
@@ -322,14 +528,16 @@ export async function doctor(vaultPath?: string): Promise<DoctorReport> {
       label: 'orphan links',
       status: 'warn',
       detail: `${linkScan.orphans.length} orphan link(s)`,
-      hint: 'Run `clawvault link --orphans` to review.'
+      hint: 'Run `clawvault link --orphans` to review.',
+      category: 'health'
     });
     warnings++;
   } else {
     checks.push({
       label: 'orphan links',
       status: 'ok',
-      detail: `${linkScan.orphans.length} orphan link(s)`
+      detail: `${linkScan.orphans.length} orphan link(s)`,
+      category: 'health'
     });
   }
 
@@ -338,14 +546,16 @@ export async function doctor(vaultPath?: string): Promise<DoctorReport> {
       label: 'inbox backlog',
       status: 'warn',
       detail: `${inbox.length} inbox item(s) pending`,
-      hint: 'Process inbox items to keep memory tidy.'
+      hint: 'Process inbox items to keep memory tidy.',
+      category: 'health'
     });
     warnings++;
   } else {
     checks.push({
       label: 'inbox backlog',
       status: 'ok',
-      detail: `${inbox.length} inbox item(s) pending`
+      detail: `${inbox.length} inbox item(s) pending`,
+      category: 'health'
     });
   }
 
@@ -354,10 +564,11 @@ export async function doctor(vaultPath?: string): Promise<DoctorReport> {
       label: 'vault activity',
       status: 'warn',
       detail: `${stats.documents} total documents`,
-      hint: 'Start capturing decisions, lessons, and projects.'
+      hint: 'Start capturing decisions, lessons, and projects.',
+      category: 'health'
     });
     warnings++;
   }
 
-  return { vaultPath: vault.getPath(), checks, warnings, errors };
+  return { vaultPath: vault.getPath(), checks, warnings, errors, migrationIssues };
 }

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -1,0 +1,388 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const {
+  hasQmdMock,
+  listQmdCollectionsMock,
+  removeQmdCollectionMock,
+  execFileSyncMock,
+  scanVaultLinksMock,
+  getObserverStalenessMock,
+  spawnSyncMock
+} = vi.hoisted(() => ({
+  hasQmdMock: vi.fn(),
+  listQmdCollectionsMock: vi.fn(),
+  removeQmdCollectionMock: vi.fn(),
+  execFileSyncMock: vi.fn(),
+  scanVaultLinksMock: vi.fn(),
+  getObserverStalenessMock: vi.fn(),
+  spawnSyncMock: vi.fn()
+}));
+
+vi.mock('../lib/search.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/search.js')>('../lib/search.js');
+  return {
+    ...actual,
+    hasQmd: hasQmdMock
+  };
+});
+
+vi.mock('../lib/qmd-collections.js', () => ({
+  listQmdCollections: listQmdCollectionsMock,
+  removeQmdCollection: removeQmdCollectionMock
+}));
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execFileSync: execFileSyncMock,
+    spawnSync: spawnSyncMock
+  };
+});
+
+vi.mock('../lib/backlinks.js', () => ({
+  scanVaultLinks: scanVaultLinksMock
+}));
+
+vi.mock('../observer/active-session-observer.js', () => ({
+  getObserverStaleness: getObserverStalenessMock
+}));
+
+let mockQmdCollection = 'vault';
+let mockQmdRoot = '/tmp/vault';
+let mockStats = { documents: 0, categories: {} as Record<string, number> };
+let mockDocuments: Array<{
+  id: string;
+  path: string;
+  category: string;
+  title: string;
+  content: string;
+  frontmatter: Record<string, unknown>;
+  links: string[];
+  tags: string[];
+  modified: Date;
+}> = [];
+let mockHandoffs: typeof mockDocuments = [];
+let mockInbox: typeof mockDocuments = [];
+
+vi.mock('../lib/vault.js', () => ({
+  ClawVault: class {
+    private vaultPath: string;
+
+    constructor(vaultPath: string) {
+      this.vaultPath = vaultPath;
+    }
+
+    async load(): Promise<void> {
+      return;
+    }
+
+    async stats(): Promise<{ documents: number; categories: Record<string, number> }> {
+      return mockStats;
+    }
+
+    async list(category?: string) {
+      if (category === 'handoffs') return mockHandoffs;
+      if (category === 'inbox') return mockInbox;
+      if (category) return [];
+      return mockDocuments;
+    }
+
+    getPath(): string {
+      return this.vaultPath;
+    }
+
+    getQmdCollection(): string {
+      return mockQmdCollection;
+    }
+
+    getQmdRoot(): string {
+      return mockQmdRoot;
+    }
+  },
+  findVault: async () => null
+}));
+
+import { migrate } from './migrate.js';
+
+function makeTempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function makeDoc(category: string, modified: Date) {
+  return {
+    id: `${category}/doc`,
+    path: `/tmp/${category}/doc.md`,
+    category,
+    title: 'doc',
+    content: '',
+    frontmatter: {},
+    links: [],
+    tags: [],
+    modified
+  };
+}
+
+const envSnapshot = {
+  HOME: process.env.HOME,
+  SHELL: process.env.SHELL,
+  CLAWVAULT_PATH: process.env.CLAWVAULT_PATH
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+  process.env.HOME = envSnapshot.HOME;
+  process.env.SHELL = envSnapshot.SHELL;
+  process.env.CLAWVAULT_PATH = envSnapshot.CLAWVAULT_PATH;
+});
+
+beforeEach(() => {
+  hasQmdMock.mockReturnValue(true);
+  listQmdCollectionsMock.mockReturnValue([]);
+  scanVaultLinksMock.mockReturnValue({
+    backlinks: new Map(),
+    orphans: [],
+    linkCount: 0
+  });
+  getObserverStalenessMock.mockReturnValue({
+    staleCount: 0,
+    oldestMs: 0,
+    newestMs: 0
+  });
+  spawnSyncMock.mockReturnValue({ status: 0, error: null });
+  mockStats = { documents: 10, categories: {} };
+  mockDocuments = [makeDoc('projects', new Date())];
+  mockHandoffs = [makeDoc('handoffs', new Date())];
+  mockInbox = [];
+});
+
+describe('migrate', () => {
+  it('reports no issues when vault is properly configured', async () => {
+    const vaultPath = makeTempDir('clawvault-migrate-ok-');
+    const homePath = makeTempDir('clawvault-home-ok-');
+    process.env.HOME = homePath;
+    process.env.SHELL = '/bin/bash';
+    fs.writeFileSync(path.join(homePath, '.bashrc'), 'export CLAWVAULT_PATH="/tmp/vault"');
+
+    mockQmdCollection = 'my-vault';
+    mockQmdRoot = vaultPath;
+
+    listQmdCollectionsMock.mockReturnValue([
+      { name: 'my-vault', uri: 'qmd://my-vault', root: vaultPath, details: {} }
+    ]);
+
+    try {
+      const result = await migrate({ vaultPath });
+      expect(result.issuesFound).toBe(0);
+      expect(result.actions).toHaveLength(0);
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+      fs.rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it('returns error when qmd is not installed', async () => {
+    hasQmdMock.mockReturnValue(false);
+    const vaultPath = makeTempDir('clawvault-migrate-noqmd-');
+    process.env.CLAWVAULT_PATH = vaultPath;
+
+    try {
+      const result = await migrate({ vaultPath });
+      expect(result.issuesFound).toBe(1);
+      expect(result.issuesFixed).toBe(0);
+      expect(result.actions[0].error).toContain('Install qmd');
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+    }
+  });
+
+  it('fixes missing qmd collection in dry run mode', async () => {
+    const vaultPath = makeTempDir('clawvault-migrate-missing-');
+    const homePath = makeTempDir('clawvault-home-missing-');
+    process.env.HOME = homePath;
+    process.env.SHELL = '/bin/bash';
+    fs.writeFileSync(path.join(homePath, '.bashrc'), 'export CLAWVAULT_PATH="/tmp/vault"');
+
+    mockQmdCollection = 'my-vault';
+    mockQmdRoot = vaultPath;
+    listQmdCollectionsMock.mockReturnValue([]);
+
+    try {
+      const result = await migrate({ vaultPath, dryRun: true });
+      expect(result.issuesFound).toBeGreaterThan(0);
+      expect(result.dryRun).toBe(true);
+      
+      const createAction = result.actions.find(a => a.type === 'missing_qmd_collection');
+      expect(createAction).toBeDefined();
+      expect(createAction?.success).toBe(true);
+      expect(createAction?.description).toContain('dry run');
+      
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+      fs.rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it('creates missing qmd collection when not in dry run', async () => {
+    const vaultPath = makeTempDir('clawvault-migrate-create-');
+    const homePath = makeTempDir('clawvault-home-create-');
+    process.env.HOME = homePath;
+    process.env.SHELL = '/bin/bash';
+    fs.writeFileSync(path.join(homePath, '.bashrc'), 'export CLAWVAULT_PATH="/tmp/vault"');
+
+    mockQmdCollection = 'my-vault';
+    mockQmdRoot = vaultPath;
+    listQmdCollectionsMock.mockReturnValue([]);
+
+    try {
+      const result = await migrate({ vaultPath, dryRun: false });
+      expect(result.issuesFound).toBeGreaterThan(0);
+      
+      const createAction = result.actions.find(a => a.type === 'missing_qmd_collection');
+      expect(createAction).toBeDefined();
+      expect(createAction?.success).toBe(true);
+      
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        'qmd',
+        ['collection', 'add', 'my-vault', vaultPath],
+        expect.any(Object)
+      );
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+      fs.rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it('renames stale v2 collection to new name', async () => {
+    const vaultPath = makeTempDir('clawvault-migrate-rename-');
+    const homePath = makeTempDir('clawvault-home-rename-');
+    process.env.HOME = homePath;
+    process.env.SHELL = '/bin/bash';
+    fs.writeFileSync(path.join(homePath, '.bashrc'), 'export CLAWVAULT_PATH="/tmp/vault"');
+
+    mockQmdCollection = 'my-new-vault';
+    mockQmdRoot = vaultPath;
+    listQmdCollectionsMock.mockReturnValue([
+      { name: 'clawvault', uri: 'qmd://clawvault', root: vaultPath, details: {} }
+    ]);
+
+    try {
+      const result = await migrate({ vaultPath, dryRun: false });
+      
+      const renameAction = result.actions.find(a => a.type === 'stale_collection_name');
+      expect(renameAction).toBeDefined();
+      expect(renameAction?.success).toBe(true);
+      
+      expect(removeQmdCollectionMock).toHaveBeenCalledWith('clawvault');
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        'qmd',
+        ['collection', 'add', 'my-new-vault', vaultPath],
+        expect.any(Object)
+      );
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+      fs.rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it('fixes wrong vault path by recreating collection', async () => {
+    const vaultPath = makeTempDir('clawvault-migrate-wrongpath-');
+    const homePath = makeTempDir('clawvault-home-wrongpath-');
+    const wrongPath = '/some/wrong/path';
+    process.env.HOME = homePath;
+    process.env.SHELL = '/bin/bash';
+    fs.writeFileSync(path.join(homePath, '.bashrc'), 'export CLAWVAULT_PATH="/tmp/vault"');
+
+    mockQmdCollection = 'my-vault';
+    mockQmdRoot = vaultPath;
+    listQmdCollectionsMock.mockReturnValue([
+      { name: 'my-vault', uri: 'qmd://my-vault', root: wrongPath, details: {} }
+    ]);
+
+    try {
+      const result = await migrate({ vaultPath, dryRun: false });
+      
+      const pathAction = result.actions.find(a => a.type === 'wrong_vault_path');
+      expect(pathAction).toBeDefined();
+      expect(pathAction?.success).toBe(true);
+      
+      expect(removeQmdCollectionMock).toHaveBeenCalledWith('my-vault');
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        'qmd',
+        ['collection', 'add', 'my-vault', vaultPath],
+        expect.any(Object)
+      );
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+      fs.rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it('removes orphaned collections pointing to vault path', async () => {
+    const vaultPath = makeTempDir('clawvault-migrate-orphan-');
+    const homePath = makeTempDir('clawvault-home-orphan-');
+    process.env.HOME = homePath;
+    process.env.SHELL = '/bin/bash';
+    fs.writeFileSync(path.join(homePath, '.bashrc'), 'export CLAWVAULT_PATH="/tmp/vault"');
+
+    mockQmdCollection = 'my-vault';
+    mockQmdRoot = vaultPath;
+    listQmdCollectionsMock.mockReturnValue([
+      { name: 'my-vault', uri: 'qmd://my-vault', root: vaultPath, details: {} },
+      { name: 'old-vault', uri: 'qmd://old-vault', root: vaultPath, details: {} }
+    ]);
+
+    try {
+      const result = await migrate({ vaultPath, dryRun: false });
+      
+      const orphanAction = result.actions.find(a => a.type === 'orphaned_collection');
+      expect(orphanAction).toBeDefined();
+      expect(orphanAction?.success).toBe(true);
+      
+      expect(removeQmdCollectionMock).toHaveBeenCalledWith('old-vault');
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+      fs.rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it('updates vault config with missing qmd settings', async () => {
+    const vaultPath = makeTempDir('clawvault-migrate-config-');
+    const homePath = makeTempDir('clawvault-home-config-');
+    process.env.HOME = homePath;
+    process.env.SHELL = '/bin/bash';
+    fs.writeFileSync(path.join(homePath, '.bashrc'), 'export CLAWVAULT_PATH="/tmp/vault"');
+
+    fs.writeFileSync(
+      path.join(vaultPath, '.clawvault.json'),
+      JSON.stringify({ name: 'my-vault', version: '1.0.0' }, null, 2)
+    );
+
+    mockQmdCollection = 'my-vault';
+    mockQmdRoot = vaultPath;
+    listQmdCollectionsMock.mockReturnValue([
+      { name: 'my-vault', uri: 'qmd://my-vault', root: vaultPath, details: {} }
+    ]);
+
+    try {
+      const result = await migrate({ vaultPath, dryRun: false });
+      
+      const configAction = result.actions.find(a => a.type === 'missing_qmd_config');
+      expect(configAction).toBeDefined();
+      expect(configAction?.success).toBe(true);
+      
+      const updatedConfig = JSON.parse(
+        fs.readFileSync(path.join(vaultPath, '.clawvault.json'), 'utf-8')
+      );
+      expect(updatedConfig.qmdCollection).toBeDefined();
+      expect(updatedConfig.qmdRoot).toBeDefined();
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+      fs.rmSync(homePath, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,0 +1,336 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Command } from 'commander';
+import { execFileSync } from 'child_process';
+import { resolveVaultPath } from '../lib/config.js';
+import { hasQmd, QMD_INSTALL_COMMAND, QMD_INSTALL_URL } from '../lib/search.js';
+import { loadVaultQmdConfig } from '../lib/vault-qmd-config.js';
+import { listQmdCollections, removeQmdCollection, type QmdCollectionInfo } from '../lib/qmd-collections.js';
+import { doctor, type MigrationIssue, type MigrationIssueType } from './doctor.js';
+
+export interface MigrateCommandOptions {
+  vaultPath?: string;
+  dryRun?: boolean;
+  force?: boolean;
+  json?: boolean;
+}
+
+export interface MigrationAction {
+  type: MigrationIssueType;
+  description: string;
+  success: boolean;
+  error?: string;
+}
+
+export interface MigrateResult {
+  vaultPath: string;
+  issuesFound: number;
+  issuesFixed: number;
+  actions: MigrationAction[];
+  dryRun: boolean;
+}
+
+function addQmdCollection(name: string, rootPath: string): void {
+  execFileSync('qmd', ['collection', 'add', name, rootPath], { stdio: 'ignore' });
+}
+
+function updateVaultConfig(
+  vaultPath: string,
+  updates: { qmdCollection?: string; qmdRoot?: string }
+): void {
+  const configPath = path.join(vaultPath, '.clawvault.json');
+  let config: Record<string, unknown> = {};
+  
+  if (fs.existsSync(configPath)) {
+    try {
+      config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    } catch {
+      config = {};
+    }
+  }
+
+  if (updates.qmdCollection !== undefined) {
+    config.qmdCollection = updates.qmdCollection;
+  }
+  if (updates.qmdRoot !== undefined) {
+    config.qmdRoot = updates.qmdRoot;
+  }
+
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+}
+
+function fixStaleCollectionName(
+  issue: MigrationIssue,
+  dryRun: boolean
+): MigrationAction {
+  const details = issue.details as { oldName: string; newName: string; root: string };
+  const action: MigrationAction = {
+    type: 'stale_collection_name',
+    description: `Rename collection "${details.oldName}" to "${details.newName}"`,
+    success: false
+  };
+
+  if (dryRun) {
+    action.success = true;
+    action.description += ' (dry run)';
+    return action;
+  }
+
+  try {
+    removeQmdCollection(details.oldName);
+    addQmdCollection(details.newName, details.root);
+    action.success = true;
+  } catch (err: any) {
+    action.error = err?.message || 'Failed to rename collection';
+  }
+
+  return action;
+}
+
+function fixMissingQmdCollection(
+  issue: MigrationIssue,
+  dryRun: boolean
+): MigrationAction {
+  const details = issue.details as { collectionName: string; expectedRoot: string };
+  const action: MigrationAction = {
+    type: 'missing_qmd_collection',
+    description: `Create qmd collection "${details.collectionName}" at "${details.expectedRoot}"`,
+    success: false
+  };
+
+  if (dryRun) {
+    action.success = true;
+    action.description += ' (dry run)';
+    return action;
+  }
+
+  try {
+    addQmdCollection(details.collectionName, details.expectedRoot);
+    action.success = true;
+  } catch (err: any) {
+    action.error = err?.message || 'Failed to create collection';
+  }
+
+  return action;
+}
+
+function fixWrongVaultPath(
+  issue: MigrationIssue,
+  dryRun: boolean
+): MigrationAction {
+  const details = issue.details as { collectionName: string; currentRoot: string; expectedRoot: string };
+  const action: MigrationAction = {
+    type: 'wrong_vault_path',
+    description: `Update collection "${details.collectionName}" path from "${details.currentRoot}" to "${details.expectedRoot}"`,
+    success: false
+  };
+
+  if (dryRun) {
+    action.success = true;
+    action.description += ' (dry run)';
+    return action;
+  }
+
+  try {
+    removeQmdCollection(details.collectionName);
+    addQmdCollection(details.collectionName, details.expectedRoot);
+    action.success = true;
+  } catch (err: any) {
+    action.error = err?.message || 'Failed to update collection path';
+  }
+
+  return action;
+}
+
+function fixOrphanedCollection(
+  issue: MigrationIssue,
+  dryRun: boolean
+): MigrationAction {
+  const details = issue.details as { collectionName: string; root: string };
+  const action: MigrationAction = {
+    type: 'orphaned_collection',
+    description: `Remove orphaned collection "${details.collectionName}"`,
+    success: false
+  };
+
+  if (dryRun) {
+    action.success = true;
+    action.description += ' (dry run)';
+    return action;
+  }
+
+  try {
+    removeQmdCollection(details.collectionName);
+    action.success = true;
+  } catch (err: any) {
+    action.error = err?.message || 'Failed to remove orphaned collection';
+  }
+
+  return action;
+}
+
+function fixMissingQmdConfig(
+  issue: MigrationIssue,
+  vaultPath: string,
+  dryRun: boolean
+): MigrationAction {
+  const vaultConfig = loadVaultQmdConfig(vaultPath);
+  const action: MigrationAction = {
+    type: 'missing_qmd_config',
+    description: `Add qmdCollection="${vaultConfig.qmdCollection}" and qmdRoot="${vaultConfig.qmdRoot}" to .clawvault.json`,
+    success: false
+  };
+
+  if (dryRun) {
+    action.success = true;
+    action.description += ' (dry run)';
+    return action;
+  }
+
+  try {
+    updateVaultConfig(vaultPath, {
+      qmdCollection: vaultConfig.qmdCollection,
+      qmdRoot: vaultConfig.qmdRoot
+    });
+    action.success = true;
+  } catch (err: any) {
+    action.error = err?.message || 'Failed to update vault config';
+  }
+
+  return action;
+}
+
+function fixIssue(
+  issue: MigrationIssue,
+  vaultPath: string,
+  dryRun: boolean
+): MigrationAction | null {
+  if (!issue.autoFixable) {
+    return null;
+  }
+
+  switch (issue.type) {
+    case 'stale_collection_name':
+      return fixStaleCollectionName(issue, dryRun);
+    case 'missing_qmd_collection':
+      return fixMissingQmdCollection(issue, dryRun);
+    case 'wrong_vault_path':
+      return fixWrongVaultPath(issue, dryRun);
+    case 'orphaned_collection':
+      return fixOrphanedCollection(issue, dryRun);
+    case 'missing_qmd_config':
+      return fixMissingQmdConfig(issue, vaultPath, dryRun);
+    default:
+      return null;
+  }
+}
+
+export async function migrate(options: MigrateCommandOptions = {}): Promise<MigrateResult> {
+  const vaultPath = resolveVaultPath({ explicitPath: options.vaultPath });
+  const dryRun = options.dryRun ?? false;
+
+  if (!hasQmd()) {
+    return {
+      vaultPath,
+      issuesFound: 1,
+      issuesFixed: 0,
+      actions: [{
+        type: 'missing_qmd_collection',
+        description: 'qmd is not installed',
+        success: false,
+        error: `Install qmd first: ${QMD_INSTALL_COMMAND}\nMore info: ${QMD_INSTALL_URL}`
+      }],
+      dryRun
+    };
+  }
+
+  const report = await doctor(vaultPath);
+  const issues = report.migrationIssues;
+  const actions: MigrationAction[] = [];
+
+  for (const issue of issues) {
+    const action = fixIssue(issue, vaultPath, dryRun);
+    if (action) {
+      actions.push(action);
+    }
+  }
+
+  const issuesFixed = actions.filter(a => a.success).length;
+
+  return {
+    vaultPath,
+    issuesFound: issues.length,
+    issuesFixed,
+    actions,
+    dryRun
+  };
+}
+
+function formatMigrateResult(result: MigrateResult): string {
+  const lines: string[] = [];
+  
+  lines.push('ClawVault Migration Report');
+  lines.push('-'.repeat(30));
+  lines.push(`Vault: ${result.vaultPath}`);
+  lines.push(`Mode: ${result.dryRun ? 'Dry Run' : 'Live'}`);
+  lines.push('');
+
+  if (result.issuesFound === 0) {
+    lines.push('✓ No migration issues found. Your vault is up to date.');
+    return lines.join('\n');
+  }
+
+  lines.push(`Found ${result.issuesFound} issue(s)`);
+  lines.push('');
+
+  for (const action of result.actions) {
+    const prefix = action.success ? '✓' : '✗';
+    lines.push(`${prefix} ${action.description}`);
+    if (action.error) {
+      lines.push(`  Error: ${action.error}`);
+    }
+  }
+
+  lines.push('');
+  if (result.dryRun) {
+    lines.push(`Would fix ${result.issuesFixed}/${result.issuesFound} issue(s).`);
+    lines.push('Run without --dry-run to apply changes.');
+  } else {
+    lines.push(`Fixed ${result.issuesFixed}/${result.issuesFound} issue(s).`);
+    if (result.issuesFixed < result.issuesFound) {
+      lines.push('Some issues require manual intervention.');
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export async function migrateCommand(options: MigrateCommandOptions = {}): Promise<MigrateResult> {
+  const result = await migrate(options);
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatMigrateResult(result));
+  }
+
+  return result;
+}
+
+export function registerMigrateCommand(program: Command): void {
+  program
+    .command('migrate')
+    .description('Auto-fix common v2→v3 migration issues (stale collections, missing qmd config, wrong paths)')
+    .option('-v, --vault <path>', 'Vault path')
+    .option('--dry-run', 'Preview changes without applying them')
+    .option('--force', 'Force migration even if no issues detected')
+    .option('--json', 'Output results as JSON')
+    .action(async (rawOptions: { vault?: string; dryRun?: boolean; force?: boolean; json?: boolean }) => {
+      await migrateCommand({
+        vaultPath: rawOptions.vault,
+        dryRun: rawOptions.dryRun,
+        force: rawOptions.force,
+        json: rawOptions.json
+      });
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,9 @@ export {
 export type {
   DoctorCheck,
   DoctorReport,
-  DoctorStatus
+  DoctorStatus,
+  MigrationIssue,
+  MigrationIssueType
 } from './commands/doctor.js';
 export { embedCommand, registerEmbedCommand } from './commands/embed.js';
 export type { EmbedCommandOptions, EmbedCommandResult } from './commands/embed.js';
@@ -95,6 +97,12 @@ export {
   registerMigrateObservationsCommand
 } from './commands/migrate-observations.js';
 export type { MigrateObservationsOptions, MigrateObservationsResult } from './commands/migrate-observations.js';
+export {
+  migrate,
+  migrateCommand,
+  registerMigrateCommand
+} from './commands/migrate.js';
+export type { MigrateCommandOptions, MigrationAction, MigrateResult } from './commands/migrate.js';
 export { syncBdCommand, registerSyncBdCommand } from './commands/sync-bd.js';
 export type { SyncBdCommandOptions } from './commands/sync-bd.js';
 export {
@@ -117,9 +125,10 @@ export {
   qmdEmbed,
   QmdUnavailableError,
   QmdConfigurationError,
-  QMD_INSTALL_COMMAND,
+  getQmdErrorDetails,  QMD_INSTALL_COMMAND,
   QMD_INSTALL_URL
 } from './lib/search.js';
+export type { QmdErrorCode, QmdErrorDetails } from './lib/search.js';
 export {
   embed,
   embedBatch,

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -10,14 +10,65 @@ import { Document, SearchResult, SearchOptions } from '../types.js';
 
 export const QMD_INSTALL_URL = 'https://github.com/tobi/qmd';
 export const QMD_INSTALL_COMMAND = 'bun install -g github:tobi/qmd';
-const QMD_NOT_INSTALLED_MESSAGE = `ClawVault requires qmd. Install: ${QMD_INSTALL_COMMAND}`;
 export const QMD_INDEX_ENV_VAR = 'CLAWVAULT_QMD_INDEX';
 
-export class QmdUnavailableError extends Error {
-  constructor(message: string = QMD_NOT_INSTALLED_MESSAGE) {
-    super(message);
-    this.name = 'QmdUnavailableError';
+export type QmdErrorCode = 
+  | 'NOT_INSTALLED'
+  | 'NOT_CONFIGURED'
+  | 'COLLECTION_NOT_FOUND'
+  | 'EXECUTION_FAILED';
+
+export interface QmdErrorDetails {
+  code: QmdErrorCode;
+  message: string;
+  hint: string;
+}
+
+const QMD_ERROR_MESSAGES: Record<QmdErrorCode, QmdErrorDetails> = {
+  NOT_INSTALLED: {
+    code: 'NOT_INSTALLED',
+    message: 'qmd is not installed',
+    hint: `Install qmd to enable ClawVault search and indexing:\n  ${QMD_INSTALL_COMMAND}\n\nFor more information: ${QMD_INSTALL_URL}`
+  },
+  NOT_CONFIGURED: {
+    code: 'NOT_CONFIGURED',
+    message: 'qmd collection is not configured',
+    hint: 'Run `clawvault doctor` to diagnose configuration issues, or `clawvault migrate` to fix common setup problems.'
+  },
+  COLLECTION_NOT_FOUND: {
+    code: 'COLLECTION_NOT_FOUND',
+    message: 'qmd collection not found',
+    hint: 'The configured qmd collection does not exist. Run `clawvault migrate` to recreate it, or `qmd collection add <name> <path>` manually.'
+  },
+  EXECUTION_FAILED: {
+    code: 'EXECUTION_FAILED',
+    message: 'qmd command failed',
+    hint: 'Run `clawvault doctor` to diagnose qmd issues.'
   }
+};
+
+export class QmdUnavailableError extends Error {
+  readonly code: QmdErrorCode;
+  readonly hint: string;
+
+  constructor(code: QmdErrorCode = 'NOT_INSTALLED', additionalContext?: string) {
+    const details = QMD_ERROR_MESSAGES[code];
+    const fullMessage = additionalContext 
+      ? `${details.message}: ${additionalContext}`
+      : details.message;
+    super(fullMessage);
+    this.name = 'QmdUnavailableError';
+    this.code = code;
+    this.hint = details.hint;
+  }
+
+  toUserMessage(): string {
+    return `Error: ${this.message}\n\n${this.hint}`;
+  }
+}
+
+export function getQmdErrorDetails(code: QmdErrorCode): QmdErrorDetails {
+  return QMD_ERROR_MESSAGES[code];
 }
 
 export class QmdConfigurationError extends Error {
@@ -133,7 +184,7 @@ function parseQmdOutput(raw: string): QmdResult[] {
 
 function ensureQmdAvailable(): void {
   if (!hasQmd()) {
-    throw new QmdUnavailableError();
+    throw new QmdUnavailableError('NOT_INSTALLED');
   }
 }
 
@@ -193,7 +244,7 @@ function execQmd(args: string[], indexName?: string): QmdResult[] {
     return parseQmdOutput(result);
   } catch (err: any) {
     if (err?.code === 'ENOENT') {
-      throw new QmdUnavailableError();
+      throw new QmdUnavailableError('NOT_INSTALLED');
     }
 
     const output = [err?.stdout, err?.stderr].filter(Boolean).join('\n');
@@ -209,10 +260,14 @@ function execQmd(args: string[], indexName?: string): QmdResult[] {
       } catch {
         // Fall through to throw a helpful error
       }
+      
+      if (output.includes('collection not found') || output.includes('no such collection')) {
+        throw new QmdUnavailableError('COLLECTION_NOT_FOUND', output.trim());
+      }
     }
 
-    const message = err?.message ? `qmd failed: ${err.message}` : 'qmd failed';
-    throw new Error(message);
+    const errorDetail = err?.message || 'unknown error';
+    throw new QmdUnavailableError('EXECUTION_FAILED', errorDetail);
   }
 }
 

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -37,7 +37,9 @@ export class ClawVault {
 
   constructor(vaultPath: string) {
     if (!hasQmd()) {
-      throw new QmdUnavailableError();
+      const error = new QmdUnavailableError('NOT_INSTALLED');
+      console.error(error.toUserMessage());
+      throw error;
     }
     this.config = {
       path: path.resolve(vaultPath),
@@ -55,7 +57,9 @@ export class ClawVault {
    */
   async init(options: Partial<VaultConfig> = {}, initFlags?: { skipBases?: boolean; skipTasks?: boolean; skipGraph?: boolean }): Promise<void> {
     if (!hasQmd()) {
-      throw new QmdUnavailableError();
+      const error = new QmdUnavailableError('NOT_INSTALLED');
+      console.error(error.toUserMessage());
+      throw error;
     }
     const vaultPath = this.config.path;
     const flags = initFlags || {};
@@ -176,7 +180,9 @@ export class ClawVault {
    */
   async load(): Promise<void> {
     if (!hasQmd()) {
-      throw new QmdUnavailableError();
+      const error = new QmdUnavailableError('NOT_INSTALLED');
+      console.error(error.toUserMessage());
+      throw error;
     }
     const vaultPath = this.config.path;
     const configPath = path.join(vaultPath, CONFIG_FILE);


### PR DESCRIPTION
Improve ClawVault error handling for `qmd` issues, enhance the `doctor` command with v2->v3 migration checks, and introduce a `migrate` command to auto-fix common migration problems.

---
<p><a href="https://cursor.com/agents?id=bc-f4ca77de-5469-40b6-84b0-bcf992a4d948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4ca77de-5469-40b6-84b0-bcf992a4d948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

