### PR TITLE
Vaults per agent

### DIFF
--- a/hooks/clawvault/handler.js
+++ b/hooks/clawvault/handler.js
@@ -462,10 +462,39 @@ function extractPluginConfig(event) {
   return {};
 }
 
+// Resolve vault path for a specific agent from agentVaults config
+function resolveAgentVaultPath(pluginConfig, agentId) {
+  if (!agentId || typeof agentId !== 'string') return null;
+  
+  const agentVaults = pluginConfig?.agentVaults;
+  if (!agentVaults || typeof agentVaults !== 'object' || Array.isArray(agentVaults)) {
+    return null;
+  }
+  
+  const agentPath = agentVaults[agentId];
+  if (!agentPath || typeof agentPath !== 'string') return null;
+  
+  return validateVaultPath(agentPath);
+}
+
 // Find vault by walking up directories
-function findVaultPath(event) {
-  // Check plugin config first (set via openclaw config set plugins.clawvault.config.vaultPath)
+// Supports per-agent vault paths via agentVaults config
+function findVaultPath(event, options = {}) {
   const pluginConfig = extractPluginConfig(event);
+  
+  // Determine agent ID for per-agent vault resolution
+  const agentId = options.agentId || resolveAgentIdForEvent(event);
+  
+  // Check agentVaults first (per-agent vault paths)
+  if (agentId) {
+    const agentVaultPath = resolveAgentVaultPath(pluginConfig, agentId);
+    if (agentVaultPath) {
+      console.log(`[clawvault] Using per-agent vault for ${agentId}: ${agentVaultPath}`);
+      return agentVaultPath;
+    }
+  }
+
+  // Check plugin config vaultPath (fallback for all agents)
   if (pluginConfig.vaultPath) {
     const validated = validateVaultPath(pluginConfig.vaultPath);
     if (validated) return validated;

--- a/hooks/clawvault/handler.test.js
+++ b/hooks/clawvault/handler.test.js
@@ -354,4 +354,157 @@ describe('clawvault hook handler', () => {
     delete process.env.OPENCLAW_PLUGIN_CLAWVAULT_VAULTPATH;
     fs.rmSync(vaultPath, { recursive: true, force: true });
   });
+
+  it('uses per-agent vault path from agentVaults config', async () => {
+    const agent1Vault = makeVaultFixture();
+    const agent2Vault = makeVaultFixture();
+    const fallbackVault = makeVaultFixture();
+
+    execFileSyncMock.mockImplementation((_command, args) => {
+      if (args[0] === 'recover') {
+        return 'Clean startup';
+      }
+      return '';
+    });
+
+    const handler = await loadHandler();
+    const event = {
+      type: 'gateway',
+      action: 'startup',
+      sessionKey: 'agent:agent1:main',
+      pluginConfig: {
+        vaultPath: fallbackVault,
+        agentVaults: {
+          agent1: agent1Vault,
+          agent2: agent2Vault
+        }
+      },
+      messages: []
+    };
+
+    await handler(event);
+
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      'clawvault',
+      expect.arrayContaining(['recover', '--clear', '-v', agent1Vault]),
+      expect.objectContaining({ shell: false })
+    );
+
+    fs.rmSync(agent1Vault, { recursive: true, force: true });
+    fs.rmSync(agent2Vault, { recursive: true, force: true });
+    fs.rmSync(fallbackVault, { recursive: true, force: true });
+  });
+
+  it('falls back to vaultPath when agent not in agentVaults', async () => {
+    const agent1Vault = makeVaultFixture();
+    const fallbackVault = makeVaultFixture();
+
+    execFileSyncMock.mockImplementation((_command, args) => {
+      if (args[0] === 'recover') {
+        return 'Clean startup';
+      }
+      return '';
+    });
+
+    const handler = await loadHandler();
+    const event = {
+      type: 'gateway',
+      action: 'startup',
+      sessionKey: 'agent:unknown-agent:main',
+      pluginConfig: {
+        vaultPath: fallbackVault,
+        agentVaults: {
+          agent1: agent1Vault
+        }
+      },
+      messages: []
+    };
+
+    await handler(event);
+
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      'clawvault',
+      expect.arrayContaining(['recover', '--clear', '-v', fallbackVault]),
+      expect.objectContaining({ shell: false })
+    );
+
+    fs.rmSync(agent1Vault, { recursive: true, force: true });
+    fs.rmSync(fallbackVault, { recursive: true, force: true });
+  });
+
+  it('uses agentVaults from context.pluginConfig', async () => {
+    const agent1Vault = makeVaultFixture();
+    const fallbackVault = makeVaultFixture();
+
+    execFileSyncMock.mockImplementation((_command, args) => {
+      if (args[0] === 'recover') {
+        return 'Clean startup';
+      }
+      return '';
+    });
+
+    const handler = await loadHandler();
+    const event = {
+      type: 'gateway',
+      action: 'startup',
+      sessionKey: 'agent:agent1:main',
+      context: {
+        pluginConfig: {
+          vaultPath: fallbackVault,
+          agentVaults: {
+            agent1: agent1Vault
+          }
+        }
+      },
+      messages: []
+    };
+
+    await handler(event);
+
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      'clawvault',
+      expect.arrayContaining(['recover', '--clear', '-v', agent1Vault]),
+      expect.objectContaining({ shell: false })
+    );
+
+    fs.rmSync(agent1Vault, { recursive: true, force: true });
+    fs.rmSync(fallbackVault, { recursive: true, force: true });
+  });
+
+  it('uses OPENCLAW_AGENT_ID env var for agent resolution when session key not available', async () => {
+    const agent1Vault = makeVaultFixture();
+    const fallbackVault = makeVaultFixture();
+    process.env.OPENCLAW_AGENT_ID = 'agent1';
+
+    execFileSyncMock.mockImplementation((_command, args) => {
+      if (args[0] === 'recover') {
+        return 'Clean startup';
+      }
+      return '';
+    });
+
+    const handler = await loadHandler();
+    const event = {
+      type: 'gateway',
+      action: 'startup',
+      pluginConfig: {
+        vaultPath: fallbackVault,
+        agentVaults: {
+          agent1: agent1Vault
+        }
+      },
+      messages: []
+    };
+
+    await handler(event);
+
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      'clawvault',
+      expect.arrayContaining(['recover', '--clear', '-v', agent1Vault]),
+      expect.objectContaining({ shell: false })
+    );
+
+    fs.rmSync(agent1Vault, { recursive: true, force: true });
+    fs.rmSync(fallbackVault, { recursive: true, force: true });
+  });
 });

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -9,7 +9,15 @@
     "properties": {
       "vaultPath": {
         "type": "string",
-        "description": "Path to the ClawVault vault directory. If not set, auto-discovered from CLAWVAULT_PATH or by walking up from cwd."
+        "description": "Path to the ClawVault vault directory. If not set, auto-discovered from CLAWVAULT_PATH or by walking up from cwd. Used as fallback when agentVaults is not set or agent not found."
+      },
+      "agentVaults": {
+        "type": "object",
+        "description": "Mapping of agent names to vault paths. Allows each agent to have its own vault. Falls back to vaultPath if agent not found.",
+        "additionalProperties": {
+          "type": "string",
+          "description": "Path to the vault directory for this agent"
+        }
       },
       "autoCheckpoint": {
         "type": "boolean",
@@ -46,7 +54,11 @@
     "vaultPath": {
       "label": "Vault Path",
       "placeholder": "~/my-vault",
-      "description": "Path to your ClawVault memory vault"
+      "description": "Path to your ClawVault memory vault (fallback when agentVaults not set)"
+    },
+    "agentVaults": {
+      "label": "Agent Vaults",
+      "description": "Per-agent vault paths (e.g., {\"agent1\": \"/path/to/vault1\", \"agent2\": \"/path/to/vault2\"})"
     },
     "autoCheckpoint": {
       "label": "Auto Checkpoint",

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -2,12 +2,18 @@ import { afterEach, describe, expect, it } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { findNearestVaultPath, resolveVaultPath } from './config.js';
+import { findNearestVaultPath, resolveVaultPath, resolveAgentVaultPath } from './config.js';
 
 const originalVaultEnv = process.env.CLAWVAULT_PATH;
 
 function makeTempDir(prefix: string): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function makeVaultFixture(prefix: string): string {
+  const dir = makeTempDir(prefix);
+  fs.writeFileSync(path.join(dir, '.clawvault.json'), '{}', 'utf-8');
+  return dir;
 }
 
 afterEach(() => {
@@ -72,6 +78,121 @@ describe('config path resolution', () => {
       );
     } finally {
       fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('per-agent vault resolution', () => {
+  it('resolves agent-specific vault path from agentVaults config', () => {
+    const agent1Vault = makeVaultFixture('clawvault-agent1-');
+    const agent2Vault = makeVaultFixture('clawvault-agent2-');
+    const fallbackVault = makeVaultFixture('clawvault-fallback-');
+    delete process.env.CLAWVAULT_PATH;
+
+    try {
+      const resolved = resolveVaultPath({
+        agentId: 'agent1',
+        pluginConfig: {
+          vaultPath: fallbackVault,
+          agentVaults: {
+            agent1: agent1Vault,
+            agent2: agent2Vault
+          }
+        }
+      });
+      expect(resolved).toBe(agent1Vault);
+    } finally {
+      fs.rmSync(agent1Vault, { recursive: true, force: true });
+      fs.rmSync(agent2Vault, { recursive: true, force: true });
+      fs.rmSync(fallbackVault, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to vaultPath when agent not in agentVaults', () => {
+    const agent1Vault = makeVaultFixture('clawvault-agent1-');
+    const fallbackVault = makeVaultFixture('clawvault-fallback-');
+    delete process.env.CLAWVAULT_PATH;
+
+    try {
+      const resolved = resolveVaultPath({
+        agentId: 'unknown-agent',
+        pluginConfig: {
+          vaultPath: fallbackVault,
+          agentVaults: {
+            agent1: agent1Vault
+          }
+        }
+      });
+      expect(resolved).toBe(fallbackVault);
+    } finally {
+      fs.rmSync(agent1Vault, { recursive: true, force: true });
+      fs.rmSync(fallbackVault, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to vaultPath when agentVaults is not set', () => {
+    const fallbackVault = makeVaultFixture('clawvault-fallback-');
+    delete process.env.CLAWVAULT_PATH;
+
+    try {
+      const resolved = resolveVaultPath({
+        agentId: 'agent1',
+        pluginConfig: {
+          vaultPath: fallbackVault
+        }
+      });
+      expect(resolved).toBe(fallbackVault);
+    } finally {
+      fs.rmSync(fallbackVault, { recursive: true, force: true });
+    }
+  });
+
+  it('explicit path takes precedence over agentVaults', () => {
+    const explicitVault = makeVaultFixture('clawvault-explicit-');
+    const agent1Vault = makeVaultFixture('clawvault-agent1-');
+    delete process.env.CLAWVAULT_PATH;
+
+    try {
+      const resolved = resolveVaultPath({
+        explicitPath: explicitVault,
+        agentId: 'agent1',
+        pluginConfig: {
+          agentVaults: {
+            agent1: agent1Vault
+          }
+        }
+      });
+      expect(resolved).toBe(explicitVault);
+    } finally {
+      fs.rmSync(explicitVault, { recursive: true, force: true });
+      fs.rmSync(agent1Vault, { recursive: true, force: true });
+    }
+  });
+
+  it('resolveAgentVaultPath returns null for invalid inputs', () => {
+    expect(resolveAgentVaultPath(undefined, 'agent1')).toBeNull();
+    expect(resolveAgentVaultPath({}, undefined)).toBeNull();
+    expect(resolveAgentVaultPath({}, '')).toBeNull();
+    expect(resolveAgentVaultPath({ agent1: '/nonexistent/path' }, 'agent1')).toBeNull();
+  });
+
+  it('resolveAgentVaultPath returns null when agent not found', () => {
+    const vault = makeVaultFixture('clawvault-agent-');
+    try {
+      const result = resolveAgentVaultPath({ agent1: vault }, 'agent2');
+      expect(result).toBeNull();
+    } finally {
+      fs.rmSync(vault, { recursive: true, force: true });
+    }
+  });
+
+  it('resolveAgentVaultPath returns validated path when agent found', () => {
+    const vault = makeVaultFixture('clawvault-agent-');
+    try {
+      const result = resolveAgentVaultPath({ agent1: vault }, 'agent1');
+      expect(result).toBe(vault);
+    } finally {
+      fs.rmSync(vault, { recursive: true, force: true });
     }
   });
 });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,6 +1,15 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+export interface AgentVaultsConfig {
+  [agentName: string]: string;
+}
+
+export interface PluginConfig {
+  vaultPath?: string;
+  agentVaults?: AgentVaultsConfig;
+}
+
 /**
  * Get the vault path from CLAWVAULT_PATH env var or throw
  */
@@ -26,15 +35,92 @@ export function findNearestVaultPath(startPath: string = process.cwd()): string 
   }
 }
 
-export function resolveVaultPath(options: { explicitPath?: string; cwd?: string } = {}): string {
+/**
+ * Validate that a path is a valid vault directory
+ */
+function validateVaultPath(vaultPath: string): string | null {
+  if (!vaultPath || typeof vaultPath !== 'string') return null;
+  
+  const resolved = path.resolve(vaultPath);
+  if (!path.isAbsolute(resolved)) return null;
+  
+  try {
+    const stat = fs.statSync(resolved);
+    if (!stat.isDirectory()) return null;
+  } catch {
+    return null;
+  }
+  
+  const configPath = path.join(resolved, '.clawvault.json');
+  if (!fs.existsSync(configPath)) return null;
+  
+  return resolved;
+}
+
+/**
+ * Resolve vault path for a specific agent from agentVaults config
+ */
+export function resolveAgentVaultPath(
+  agentVaults: AgentVaultsConfig | undefined,
+  agentId: string | undefined
+): string | null {
+  if (!agentId || typeof agentId !== 'string') return null;
+  if (!agentVaults || typeof agentVaults !== 'object' || Array.isArray(agentVaults)) {
+    return null;
+  }
+  
+  const agentPath = agentVaults[agentId];
+  if (!agentPath || typeof agentPath !== 'string') return null;
+  
+  return validateVaultPath(agentPath);
+}
+
+export interface ResolveVaultPathOptions {
+  explicitPath?: string;
+  cwd?: string;
+  agentId?: string;
+  pluginConfig?: PluginConfig;
+}
+
+/**
+ * Resolve vault path with support for per-agent vault paths.
+ * 
+ * Resolution order:
+ * 1. Explicit path (--vault flag)
+ * 2. Per-agent vault from agentVaults config (if agentId provided)
+ * 3. Plugin config vaultPath (fallback for all agents)
+ * 4. CLAWVAULT_PATH environment variable
+ * 5. Walk up from cwd to find nearest vault
+ */
+export function resolveVaultPath(options: ResolveVaultPathOptions = {}): string {
+  // 1. Explicit path takes precedence
   if (options.explicitPath) {
     return path.resolve(options.explicitPath);
   }
 
+  // 2. Check agentVaults for per-agent vault path
+  if (options.agentId && options.pluginConfig?.agentVaults) {
+    const agentVaultPath = resolveAgentVaultPath(
+      options.pluginConfig.agentVaults,
+      options.agentId
+    );
+    if (agentVaultPath) {
+      return agentVaultPath;
+    }
+  }
+
+  // 3. Check plugin config vaultPath (fallback)
+  if (options.pluginConfig?.vaultPath) {
+    const validated = validateVaultPath(options.pluginConfig.vaultPath);
+    if (validated) return validated;
+  }
+
+  // 4. Check CLAWVAULT_PATH environment variable
   if (process.env.CLAWVAULT_PATH) {
     return path.resolve(process.env.CLAWVAULT_PATH);
   }
 
+  // 5. Walk up from cwd to find nearest vault
   const discovered = findNearestVaultPath(options.cwd ?? process.cwd());
   if (discovered) {
     return discovered;


### PR DESCRIPTION
Adds support for per-agent vault paths in the plugin configuration, falling back to a single vault path if not specified, to address GitHub issue #74.

---
<p><a href="https://cursor.com/agents?id=bc-1897a2e9-a702-41dc-8c6a-47620f73647e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1897a2e9-a702-41dc-8c6a-47620f73647e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

