### PR TITLE
Workgraph CLI product demo

### DIFF
--- a/packages/workgraph/README.md
+++ b/packages/workgraph/README.md
@@ -56,6 +56,24 @@ workgraph command-center --output "ops/Command Center.md" --json
 workgraph bases generate --refresh-registry --json
 ```
 
+## One-command product demo bootstrap
+
+```bash
+workgraph demo bootstrap /tmp/workgraph-product-demo --json
+```
+
+This command initializes a fresh standalone workspace, defines custom malleable primitives (`milestone`, `release-gate`), runs a multi-agent thread lifecycle (claim/block/unblock/done), generates a command center snapshot, and verifies ledger hash-chain integrity.
+
+## Deep standalone CLI validation
+
+From `packages/workgraph/`:
+
+```bash
+npm run test:e2e
+```
+
+This executes a full CLI contract and behavior harness against a clean workspace, including success and expected-failure flows (idempotent init, claim contention, owner checks, ledger verification, skill lifecycle, and `.base` generation).
+
 ### JSON contract
 
 All commands support `--json` and emit:

--- a/packages/workgraph/package.json
+++ b/packages/workgraph/package.json
@@ -30,6 +30,8 @@
     "build": "tsup src/index.ts src/cli.ts --format esm --dts --clean",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --config vitest.config.ts",
+    "test:e2e": "npm run build && node scripts/standalone-cli-e2e.mjs",
+    "demo:product": "npm run build && node scripts/standalone-cli-e2e.mjs --workspace /tmp/workgraph-product-demo-cli --keep",
     "ci": "npm run typecheck && npm run test && npm run build",
     "prepublishOnly": "npm run ci"
   },

--- a/packages/workgraph/scripts/standalone-cli-e2e.mjs
+++ b/packages/workgraph/scripts/standalone-cli-e2e.mjs
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(scriptDir, '..');
+const cliPath = path.join(packageRoot, 'bin', 'workgraph.js');
+
+const options = parseArgs(process.argv.slice(2));
+const workspacePath = options.workspace
+  ? path.resolve(options.workspace)
+  : fs.mkdtempSync(path.join(os.tmpdir(), 'workgraph-cli-e2e-'));
+const keepWorkspace = options.keep || Boolean(options.workspace);
+
+let summary = null;
+
+try {
+  if (fs.existsSync(workspacePath)) {
+    fs.rmSync(workspacePath, { recursive: true, force: true });
+  }
+
+  console.log(`Using workspace: ${workspacePath}`);
+
+  const demo = runJson(
+    [
+      'demo',
+      'bootstrap',
+      workspacePath,
+      '--name',
+      'Standalone CLI Product Demo',
+      '--actor',
+      'agent-lead',
+      '--worker-one',
+      'agent-worker-1',
+      '--worker-two',
+      'agent-worker-2',
+    ],
+    'Bootstrap product-demo workspace',
+  );
+  assert(Array.isArray(demo.customTypes) && demo.customTypes.includes('milestone'),
+    'Demo bootstrap must include custom primitive "milestone"');
+  assert(Array.isArray(demo.threads.completed) && demo.threads.completed.length >= 4,
+    'Demo bootstrap must complete at least 4 threads');
+
+  const reinitError = runJson(
+    ['init', workspacePath],
+    'Re-initialization must fail',
+    { expectSuccess: false },
+  );
+  assert(
+    typeof reinitError === 'string' && reinitError.includes('already initialized'),
+    'Re-initialization should return "already initialized" error',
+  );
+
+  const primitiveList = runJson(
+    ['primitive', 'list', '--workspace', workspacePath],
+    'List primitives in demo workspace',
+  );
+  const primitiveNames = primitiveList.types.map((typeDef) => typeDef.name);
+  assert(primitiveNames.includes('milestone'), 'Primitive list should include milestone');
+  assert(primitiveNames.includes('release-gate'), 'Primitive list should include release-gate');
+
+  const doneThreads = runJson(
+    ['thread', 'list', '--status', 'done', '--workspace', workspacePath],
+    'List completed threads',
+  );
+  assert(doneThreads.count >= 4, 'Expected at least 4 completed threads after demo bootstrap');
+
+  const emptyNextError = runJson(
+    ['thread', 'next', '--claim', '--fail-on-empty', '--actor', 'agent-worker-1', '--workspace', workspacePath],
+    'Ensure empty queue fails when requested',
+    { expectSuccess: false },
+  );
+  assert(
+    typeof emptyNextError === 'string' && emptyNextError.includes('No ready threads available'),
+    'Expected fail-on-empty command to report no ready threads',
+  );
+
+  const edgeThread = runJson(
+    [
+      'thread',
+      'create',
+      'Claim contention check',
+      '--goal',
+      'Validate claim ownership protections',
+      '--actor',
+      'agent-lead',
+      '--workspace',
+      workspacePath,
+    ],
+    'Create contention-check thread',
+  ).thread;
+
+  runJson(
+    ['thread', 'claim', edgeThread.path, '--actor', 'agent-worker-1', '--workspace', workspacePath],
+    'Claim edge thread with worker one',
+  );
+
+  const doubleClaimError = runJson(
+    ['thread', 'claim', edgeThread.path, '--actor', 'agent-worker-2', '--workspace', workspacePath],
+    'Double claim should fail',
+    { expectSuccess: false },
+  );
+  assert(
+    typeof doubleClaimError === 'string' && doubleClaimError.includes('Cannot claim thread'),
+    'Expected double claim to fail with status error',
+  );
+
+  const nonOwnerReleaseError = runJson(
+    ['thread', 'release', edgeThread.path, '--actor', 'agent-worker-2', '--workspace', workspacePath],
+    'Non-owner release should fail',
+    { expectSuccess: false },
+  );
+  assert(
+    typeof nonOwnerReleaseError === 'string' && nonOwnerReleaseError.includes('owned by'),
+    'Expected non-owner release to fail with ownership error',
+  );
+
+  runJson(
+    ['thread', 'release', edgeThread.path, '--actor', 'agent-worker-1', '--workspace', workspacePath],
+    'Release edge thread by owner',
+  );
+  runJson(
+    ['thread', 'claim', edgeThread.path, '--actor', 'agent-worker-2', '--workspace', workspacePath],
+    'Re-claim edge thread by worker two',
+  );
+  runJson(
+    [
+      'thread',
+      'done',
+      edgeThread.path,
+      '--actor',
+      'agent-worker-2',
+      '--output',
+      'Ownership and contention checks passed.',
+      '--workspace',
+      workspacePath,
+    ],
+    'Complete edge thread',
+  );
+
+  const verify = runJson(
+    ['ledger', 'verify', '--strict', '--workspace', workspacePath],
+    'Verify tamper-evident ledger chain',
+  );
+  assert(verify.ok === true, 'Ledger verification must pass');
+  assert(Array.isArray(verify.issues) && verify.issues.length === 0, 'Ledger verification should have no issues');
+
+  const doneQuery = runJson(
+    ['ledger', 'query', '--op', 'done', '--workspace', workspacePath],
+    'Query done operations',
+  );
+  assert(doneQuery.entries.length >= 5, 'Expected done operations for demo plus edge thread');
+
+  const blame = runJson(
+    ['ledger', 'blame', edgeThread.path, '--workspace', workspacePath],
+    'Show attribution for edge thread',
+  );
+  const blameActors = blame.actors.map((item) => item.actor);
+  assert(blameActors.includes('agent-worker-1'), 'Blame should include agent-worker-1');
+  assert(blameActors.includes('agent-worker-2'), 'Blame should include agent-worker-2');
+
+  const skill = runJson(
+    [
+      'skill',
+      'write',
+      'Standalone Ops Manual',
+      '--actor',
+      'agent-lead',
+      '--owner',
+      'agent-lead',
+      '--status',
+      'draft',
+      '--tags',
+      'workgraph,demo',
+      '--body',
+      '# Standalone Ops Manual\n\n- Build\n- Test\n- Demo',
+      '--workspace',
+      workspacePath,
+    ],
+    'Write skill primitive',
+  ).skill;
+
+  runJson(
+    [
+      'skill',
+      'propose',
+      'standalone-ops-manual',
+      '--actor',
+      'agent-reviewer',
+      '--space',
+      'spaces/standalone-cli-program.md',
+      '--workspace',
+      workspacePath,
+    ],
+    'Propose skill primitive',
+  );
+
+  runJson(
+    ['skill', 'promote', 'standalone-ops-manual', '--actor', 'agent-lead', '--workspace', workspacePath],
+    'Promote skill primitive',
+  );
+
+  const loadedSkill = runJson(
+    ['skill', 'load', skill.path, '--workspace', workspacePath],
+    'Load promoted skill',
+  ).skill;
+  assert(loadedSkill.fields.status === 'active', 'Promoted skill should be active');
+
+  const activeSkills = runJson(
+    ['skill', 'list', '--status', 'active', '--workspace', workspacePath],
+    'List active skills',
+  );
+  assert(activeSkills.count >= 1, 'Expected at least one active skill');
+
+  const commandCenter = runJson(
+    ['command-center', '--output', 'ops/Command Center.md', '--workspace', workspacePath],
+    'Generate command center snapshot',
+  );
+  const commandCenterAbsolute = path.join(workspacePath, commandCenter.outputPath);
+  assert(fs.existsSync(commandCenterAbsolute), 'Command center file should exist on disk');
+
+  const bases = runJson(
+    ['bases', 'generate', '--all', '--refresh-registry', '--workspace', workspacePath],
+    'Generate bases including custom primitives',
+  );
+  assert(
+    bases.generated.includes('.clawvault/bases/release-gate.base'),
+    'Bases generation should include release-gate.base',
+  );
+  assert(
+    bases.generated.includes('.clawvault/bases/skill.base'),
+    'Bases generation should include skill.base',
+  );
+
+  summary = {
+    workspacePath,
+    commandCenterPath: commandCenter.outputPath,
+    totalDoneOps: doneQuery.entries.length,
+    primitiveCount: primitiveList.count,
+    activeSkillCount: activeSkills.count,
+    ledgerEntries: verify.entries,
+  };
+
+  console.log('Standalone CLI E2E: PASS');
+  console.log(JSON.stringify(summary, null, 2));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Standalone CLI E2E: FAIL\n${message}`);
+  process.exitCode = 1;
+} finally {
+  if (!keepWorkspace && summary) {
+    fs.rmSync(workspacePath, { recursive: true, force: true });
+  }
+}
+
+function runJson(args, label, options = { expectSuccess: true }) {
+  const commandArgs = args.includes('--json') ? args : [...args, '--json'];
+  const result = spawnSync(process.execPath, [cliPath, ...commandArgs], {
+    cwd: packageRoot,
+    encoding: 'utf-8',
+  });
+
+  const output = (result.stdout.trim() || result.stderr.trim());
+  if (!output) {
+    throw new Error(`${label}: command produced no JSON output`);
+  }
+
+  let envelope;
+  try {
+    envelope = JSON.parse(output);
+  } catch {
+    throw new Error(`${label}: could not parse JSON output\n${output}`);
+  }
+
+  if (options.expectSuccess) {
+    if (result.status !== 0) {
+      throw new Error(`${label}: command exited with ${result.status}\n${output}`);
+    }
+    if (!envelope.ok) {
+      throw new Error(`${label}: expected success envelope\n${output}`);
+    }
+    console.log(`PASS: ${label}`);
+    return envelope.data;
+  }
+
+  if (result.status === 0) {
+    throw new Error(`${label}: expected command failure but it succeeded`);
+  }
+  if (envelope.ok !== false) {
+    throw new Error(`${label}: expected failure JSON envelope\n${output}`);
+  }
+  console.log(`PASS: ${label} (expected failure)`);
+  return envelope.error;
+}
+
+function parseArgs(args) {
+  const parsed = {
+    workspace: undefined,
+    keep: false,
+  };
+
+  for (let idx = 0; idx < args.length; idx++) {
+    const token = args[idx];
+    if (token === '--workspace') {
+      parsed.workspace = args[idx + 1];
+      idx += 1;
+      continue;
+    }
+    if (token === '--keep') {
+      parsed.keep = true;
+      continue;
+    }
+  }
+
+  return parsed;
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}

--- a/packages/workgraph/src/cli.ts
+++ b/packages/workgraph/src/cli.ts
@@ -845,6 +845,52 @@ addWorkspaceOption(
   )
 );
 
+// ============================================================================
+// demo
+// ============================================================================
+
+const demoCmd = program
+  .command('demo')
+  .description('Bootstrap and validate a product-demo workgraph workspace');
+
+addWorkspaceOption(
+  demoCmd
+    .command('bootstrap [path]')
+    .description('Create a complete standalone product-demo workspace state')
+    .option('-n, --name <name>', 'Workspace name')
+    .option('-a, --actor <name>', 'Lead actor name', DEFAULT_ACTOR)
+    .option('--worker-one <name>', 'Primary worker actor', 'agent-worker-1')
+    .option('--worker-two <name>', 'Secondary worker actor', 'agent-worker-2')
+    .option(
+      '--command-center-output <path>',
+      'Command center markdown output path',
+      'ops/Command Center.md'
+    )
+    .option('--json', 'Emit structured JSON output')
+).action((targetPath, opts) =>
+  runCommand(
+    opts,
+    () => {
+      const workspacePath = path.resolve(targetPath || resolveWorkspacePath(opts));
+      return workgraph.demo.bootstrapProductDemo(workspacePath, {
+        name: opts.name,
+        actor: opts.actor,
+        workerOne: opts.workerOne,
+        workerTwo: opts.workerTwo,
+        commandCenterPath: opts.commandCenterOutput,
+      });
+    },
+    (result) => [
+      `Bootstrapped demo workspace: ${result.workspacePath}`,
+      `Custom primitives: ${result.customTypes.join(', ')}`,
+      `Threads completed: ${result.threads.completed.length}`,
+      `Command center: ${result.commandCenterPath}`,
+      `Ledger entries: ${result.ledger.entries}`,
+      `Ledger hash-chain valid: ${result.ledger.ok}`,
+    ]
+  )
+);
+
 program.parse();
 
 function addWorkspaceOption<T extends Command>(command: T): T {

--- a/packages/workgraph/src/demo.test.ts
+++ b/packages/workgraph/src/demo.test.ts
@@ -1,0 +1,71 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { bootstrapProductDemo } from './demo.js';
+import { verifyHashChain, historyOf } from './ledger.js';
+import { listTypes } from './registry.js';
+import { list, read } from './store.js';
+import { isWorkgraphWorkspace } from './workspace.js';
+
+let workspacePath: string;
+
+beforeEach(() => {
+  workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'wg-product-demo-'));
+  fs.rmSync(workspacePath, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  fs.rmSync(workspacePath, { recursive: true, force: true });
+});
+
+describe('demo bootstrap', () => {
+  it('builds a fully-initialized standalone workspace with malleable primitives', () => {
+    const result = bootstrapProductDemo(workspacePath, {
+      name: 'Demo QA Workspace',
+      commandCenterPath: 'ops/Command Center.md',
+    });
+
+    expect(result.workspacePath).toBe(path.resolve(workspacePath));
+    expect(isWorkgraphWorkspace(workspacePath)).toBe(true);
+    expect(result.customTypes).toEqual(['milestone', 'release-gate']);
+    expect(result.generatedBases).toContain('.clawvault/bases/milestone.base');
+    expect(result.generatedBases).toContain('.clawvault/bases/release-gate.base');
+
+    const registryTypes = listTypes(workspacePath).map((typeDef) => typeDef.name);
+    expect(registryTypes).toContain('milestone');
+    expect(registryTypes).toContain('release-gate');
+
+    const threads = list(workspacePath, 'thread');
+    expect(threads).toHaveLength(4);
+    expect(threads.every((thread) => thread.fields.status === 'done')).toBe(true);
+
+    const releaseGate = read(workspacePath, result.customPrimitives.releaseGate);
+    expect(releaseGate).not.toBeNull();
+    expect(releaseGate?.fields.go_no_go).toBe('go');
+    expect(releaseGate?.fields.status).toBe('ready');
+
+    const commandCenterPath = path.join(workspacePath, result.commandCenterPath);
+    expect(fs.existsSync(commandCenterPath)).toBe(true);
+    const commandCenter = fs.readFileSync(commandCenterPath, 'utf-8');
+    expect(commandCenter).toContain('# Workgraph Command Center');
+    expect(commandCenter).toContain('## Recent Ledger Activity');
+
+    const verify = verifyHashChain(workspacePath, { strict: true });
+    expect(verify.ok).toBe(true);
+    expect(verify.issues).toEqual([]);
+    expect(verify.entries).toBeGreaterThan(0);
+
+    const childHistory = historyOf(workspacePath, result.threads.children[1]);
+    const childOps = new Set(childHistory.map((entry) => entry.op));
+    expect(childOps).toContain('claim');
+    expect(childOps).toContain('block');
+    expect(childOps).toContain('unblock');
+    expect(childOps).toContain('done');
+  });
+
+  it('throws if bootstrapping into an already-initialized workspace', () => {
+    bootstrapProductDemo(workspacePath);
+    expect(() => bootstrapProductDemo(workspacePath)).toThrow('already initialized');
+  });
+});

--- a/packages/workgraph/src/demo.ts
+++ b/packages/workgraph/src/demo.ts
@@ -1,0 +1,295 @@
+/**
+ * Opinionated product-demo bootstrap for standalone workgraph CLI.
+ */
+
+import * as bases from './bases.js';
+import * as commandCenter from './command-center.js';
+import * as ledger from './ledger.js';
+import * as registry from './registry.js';
+import * as store from './store.js';
+import * as thread from './thread.js';
+import * as workspace from './workspace.js';
+import type { PrimitiveInstance } from './types.js';
+
+export interface BootstrapProductDemoOptions {
+  name?: string;
+  actor?: string;
+  workerOne?: string;
+  workerTwo?: string;
+  commandCenterPath?: string;
+}
+
+export interface BootstrapProductDemoResult {
+  workspacePath: string;
+  commandCenterPath: string;
+  seededTypes: string[];
+  customTypes: string[];
+  spaces: string[];
+  threads: {
+    parent: string;
+    children: string[];
+    completed: string[];
+  };
+  customPrimitives: {
+    milestone: string;
+    releaseGate: string;
+  };
+  generatedBases: string[];
+  ledger: {
+    ok: boolean;
+    entries: number;
+    lastHash: string;
+  };
+}
+
+const DEFAULT_LEAD = 'agent-lead';
+const DEFAULT_WORKER_ONE = 'agent-worker-1';
+const DEFAULT_WORKER_TWO = 'agent-worker-2';
+
+export function bootstrapProductDemo(
+  targetPath: string,
+  options: BootstrapProductDemoOptions = {},
+): BootstrapProductDemoResult {
+  const lead = options.actor ?? DEFAULT_LEAD;
+  const workerOne = options.workerOne ?? DEFAULT_WORKER_ONE;
+  const workerTwo = options.workerTwo ?? DEFAULT_WORKER_TWO;
+
+  const initialized = workspace.initWorkspace(targetPath, {
+    name: options.name ?? 'Standalone Workgraph Product Demo',
+  });
+  const workspacePath = initialized.workspacePath;
+
+  defineDemoPrimitives(workspacePath, lead);
+  bases.syncPrimitiveRegistryManifest(workspacePath);
+  const generatedBases = bases.generateBasesFromPrimitiveRegistry(workspacePath, {
+    includeNonCanonical: true,
+  });
+
+  const demoSpace = store.create(
+    workspacePath,
+    'space',
+    {
+      title: 'Standalone CLI Program',
+      description: 'Execution lane for the standalone workgraph CLI release.',
+      members: [lead, workerOne, workerTwo],
+      tags: ['demo', 'release', 'workgraph'],
+    },
+    '# Standalone CLI Program\n\nShared lane for product-demo execution.',
+    lead,
+  );
+
+  const parentThread = thread.createThread(
+    workspacePath,
+    'Ship standalone workgraph CLI',
+    'Deliver a production-grade standalone CLI with a reproducible product walkthrough.',
+    lead,
+    {
+      priority: 'high',
+      space: demoSpace.path,
+      tags: ['release', 'demo'],
+    },
+  );
+
+  const decomposed = thread.decompose(
+    workspacePath,
+    parentThread.path,
+    [
+      {
+        title: 'Harden CLI contract',
+        goal: 'Validate command JSON envelopes and error semantics for automation.',
+      },
+      {
+        title: 'Exercise multi-agent workspace',
+        goal: 'Run claim/block/unblock/done lifecycle against realistic workspace state.',
+      },
+      {
+        title: 'Record product walkthrough',
+        goal: 'Capture end-to-end demo steps with ledger and command-center proof.',
+      },
+    ],
+    lead,
+  );
+
+  const [contractThread, workspaceThread, walkthroughThread] = decomposed;
+  if (!contractThread || !workspaceThread || !walkthroughThread) {
+    throw new Error('Failed to create demo child threads');
+  }
+
+  // Encode deterministic sequencing for `thread next --claim` demo flows.
+  store.update(workspacePath, workspaceThread.path, { deps: [contractThread.path] }, undefined, lead);
+  store.update(workspacePath, walkthroughThread.path, { deps: [workspaceThread.path] }, undefined, lead);
+
+  const milestone = store.create(
+    workspacePath,
+    'milestone',
+    {
+      title: 'Standalone CLI launch milestone',
+      status: 'pending',
+      target_date: '2026-04-01',
+      thread_refs: [contractThread.path, workspaceThread.path, walkthroughThread.path],
+    },
+    '# Launch Milestone\n\nTracks readiness of the standalone CLI launch threads.',
+    lead,
+  );
+
+  const releaseGate = store.create(
+    workspacePath,
+    'release-gate',
+    {
+      title: 'Standalone CLI release gate',
+      owner: lead,
+      go_no_go: 'pending',
+      milestone_ref: milestone.path,
+      thread_refs: [contractThread.path, workspaceThread.path, walkthroughThread.path],
+    },
+    '# Release Gate\n\nFinal go/no-go checkpoint for the standalone CLI.',
+    lead,
+  );
+
+  runDemoLifecycle(
+    workspacePath,
+    lead,
+    workerOne,
+    workerTwo,
+    parentThread.path,
+    contractThread.path,
+    workspaceThread.path,
+    walkthroughThread.path,
+  );
+
+  store.update(
+    workspacePath,
+    releaseGate.path,
+    {
+      go_no_go: 'go',
+      status: 'ready',
+    },
+    undefined,
+    lead,
+  );
+
+  const commandCenterResult = commandCenter.generateCommandCenter(workspacePath, {
+    actor: lead,
+    outputPath: options.commandCenterPath ?? 'ops/Command Center.md',
+    recentCount: 30,
+  });
+
+  const verification = ledger.verifyHashChain(workspacePath, { strict: true });
+  if (!verification.ok) {
+    throw new Error(`Ledger hash-chain verification failed: ${verification.issues.join('; ')}`);
+  }
+
+  return {
+    workspacePath,
+    commandCenterPath: commandCenterResult.outputPath,
+    seededTypes: initialized.seededTypes,
+    customTypes: ['milestone', 'release-gate'],
+    spaces: [demoSpace.path],
+    threads: {
+      parent: parentThread.path,
+      children: [contractThread.path, workspaceThread.path, walkthroughThread.path],
+      completed: [contractThread.path, workspaceThread.path, walkthroughThread.path, parentThread.path],
+    },
+    customPrimitives: {
+      milestone: milestone.path,
+      releaseGate: releaseGate.path,
+    },
+    generatedBases: generatedBases.generated,
+    ledger: {
+      ok: verification.ok,
+      entries: verification.entries,
+      lastHash: verification.lastHash,
+    },
+  };
+}
+
+function defineDemoPrimitives(workspacePath: string, actor: string): void {
+  registry.defineType(
+    workspacePath,
+    'milestone',
+    'A release checkpoint bundling thread outcomes and dates.',
+    {
+      thread_refs: { type: 'list', default: [] },
+      target_date: { type: 'date' },
+      status: { type: 'string', default: 'pending' },
+    },
+    actor,
+    'milestones',
+  );
+
+  registry.defineType(
+    workspacePath,
+    'release-gate',
+    'Go/no-go coordination primitive for production launch decisions.',
+    {
+      owner: { type: 'string', required: true },
+      go_no_go: { type: 'string', default: 'pending' },
+      status: { type: 'string', default: 'collecting-evidence' },
+      milestone_ref: { type: 'ref', required: true },
+      thread_refs: { type: 'list', default: [] },
+    },
+    actor,
+    'release-gates',
+  );
+}
+
+function runDemoLifecycle(
+  workspacePath: string,
+  lead: string,
+  workerOne: string,
+  workerTwo: string,
+  parentPath: string,
+  contractPath: string,
+  workspaceThreadPath: string,
+  walkthroughPath: string,
+): void {
+  const claimOne = assertClaim(thread.claimNextReady(workspacePath, workerOne), contractPath);
+  thread.done(
+    workspacePath,
+    claimOne.path,
+    workerOne,
+    'Validated JSON contract and CLI integration behavior across core commands.',
+  );
+
+  const claimTwo = assertClaim(thread.claimNextReady(workspacePath, workerTwo), workspaceThreadPath);
+  thread.block(
+    workspacePath,
+    claimTwo.path,
+    workerTwo,
+    'external/demo-assets',
+    'Waiting for final artifact template and narration alignment.',
+  );
+  thread.unblock(workspacePath, claimTwo.path, lead);
+  thread.done(
+    workspacePath,
+    claimTwo.path,
+    workerTwo,
+    'Executed realistic multi-agent collaboration flow in a clean workspace.',
+  );
+
+  const claimThree = assertClaim(thread.claimNextReady(workspacePath, workerOne), walkthroughPath);
+  thread.done(
+    workspacePath,
+    claimThree.path,
+    workerOne,
+    'Recorded walkthrough and captured ledger + command-center evidence.',
+  );
+
+  const claimParent = assertClaim(thread.claimNextReady(workspacePath, lead), parentPath);
+  thread.done(
+    workspacePath,
+    claimParent.path,
+    lead,
+    'Standalone CLI shipped with reproducible product demo and verification artifacts.',
+  );
+}
+
+function assertClaim(instance: PrimitiveInstance | null, expectedPath: string): PrimitiveInstance {
+  if (!instance) {
+    throw new Error(`Expected claimable thread ${expectedPath}, but queue was empty`);
+  }
+  if (instance.path !== expectedPath) {
+    throw new Error(`Expected to claim ${expectedPath}, got ${instance.path}`);
+  }
+  return instance;
+}

--- a/packages/workgraph/src/index.ts
+++ b/packages/workgraph/src/index.ts
@@ -11,3 +11,4 @@ export * as workspace from './workspace.js';
 export * as commandCenter from './command-center.js';
 export * as bases from './bases.js';
 export * as skill from './skill.js';
+export * as demo from './demo.js';


### PR DESCRIPTION
Adds a `workgraph demo bootstrap` CLI command and E2E tests to provide a fully demoable and verifiable standalone `workgraph` CLI.

---
<p><a href="https://cursor.com/agents/bc-a74df466-deaa-4563-a434-6c8301685c47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a74df466-deaa-4563-a434-6c8301685c47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

