### PR TITLE
Wiki-link parsing logic

### DIFF
--- a/src/lib/backlinks.test.ts
+++ b/src/lib/backlinks.test.ts
@@ -53,4 +53,49 @@ describe('backlinks scan', () => {
       fs.rmSync(vaultPath, { recursive: true, force: true });
     }
   });
+
+  it('ignores wiki links in markdown code regions and still parses aliases', () => {
+    const vaultPath = makeTempVaultDir();
+    try {
+      writeFile(vaultPath, 'people/alice.md', '# Alice');
+      writeFile(
+        vaultPath,
+        'notes/a.md',
+        [
+          'Real: [[people/alice|Alice]].',
+          '',
+          'Inline: `[[unknown-inline]]`',
+          '',
+          '```md',
+          '[[unknown-fenced]]',
+          '```',
+          '',
+          '    [[unknown-indented]]'
+        ].join('\n')
+      );
+
+      const result = scanVaultLinks(vaultPath);
+      expect(result.linkCount).toBe(1);
+      expect(result.backlinks.get('people/alice')).toEqual(['notes/a']);
+      expect(result.orphans).toEqual([]);
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves relative links from notes in subdirectories', () => {
+    const vaultPath = makeTempVaultDir();
+    try {
+      writeFile(vaultPath, 'notes/daily/project-plan.md', '# Plan');
+      writeFile(vaultPath, 'notes/shared/retro.md', '# Retro');
+      writeFile(vaultPath, 'notes/daily/today.md', 'See [[project-plan]] and [[../shared/retro|retro]].');
+
+      const result = scanVaultLinks(vaultPath);
+      expect(result.backlinks.get('notes/daily/project-plan')).toEqual(['notes/daily/today']);
+      expect(result.backlinks.get('notes/shared/retro')).toEqual(['notes/daily/today']);
+      expect(result.orphans).toEqual([]);
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/lib/backlinks.ts
+++ b/src/lib/backlinks.ts
@@ -1,10 +1,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { buildEntityIndex, type EntityIndex } from './entity-index.js';
+import { extractRawWikiLinks, normalizeWikiLinkTarget } from './wiki-links.js';
 
 const CLAWVAULT_DIR = '.clawvault';
 const BACKLINKS_FILE = 'backlinks.json';
-const WIKI_LINK_REGEX = /\[\[([^\]]+)\]\]/g;
 
 export interface BacklinksScanResult {
   backlinks: Map<string, string[]>;
@@ -26,29 +26,55 @@ function toVaultId(vaultPath: string, filePath: string): string {
 }
 
 function normalizeLinkTarget(raw: string): string {
-  let target = raw.trim();
-  if (!target) return '';
-  if (target.startsWith('[[') && target.endsWith(']]')) {
-    target = target.slice(2, -2);
+  return normalizeWikiLinkTarget(raw);
+}
+
+function normalizeLookupCandidate(value: string): string {
+  const normalized = normalizeLinkTarget(value);
+  if (!normalized) return '';
+
+  const resolved = path.posix.normalize(normalized).replace(/^\/+/, '');
+  if (!resolved || resolved === '.' || resolved.startsWith('../')) {
+    return '';
   }
-  const pipeIndex = target.indexOf('|');
-  if (pipeIndex !== -1) {
-    target = target.slice(0, pipeIndex);
+
+  return resolved;
+}
+
+function buildLookupCandidates(target: string, sourceId: string): string[] {
+  const candidates: string[] = [];
+  const sourceDir = path.posix.dirname(sourceId);
+  const hasSourceDir = sourceDir !== '.';
+  const isRelativeTarget = target.startsWith('./') || target.startsWith('../');
+
+  const addCandidate = (candidate: string): void => {
+    const normalized = normalizeLookupCandidate(candidate);
+    if (!normalized || candidates.includes(normalized)) return;
+    candidates.push(normalized);
+  };
+
+  if (isRelativeTarget) {
+    if (hasSourceDir) {
+      addCandidate(path.posix.join(sourceDir, target));
+    } else {
+      addCandidate(target);
+    }
+    if (target.startsWith('./')) {
+      addCandidate(target.slice(2));
+    }
+    return candidates;
   }
-  if (target.startsWith('#')) return '';
-  const hashIndex = target.indexOf('#');
-  if (hashIndex !== -1) {
-    target = target.slice(0, hashIndex);
+
+  if (!target.includes('/')) {
+    if (hasSourceDir) {
+      addCandidate(`${sourceDir}/${target}`);
+    }
+    addCandidate(target);
+    return candidates;
   }
-  target = target.trim();
-  if (!target) return '';
-  if (target.endsWith('.md')) {
-    target = target.slice(0, -3);
-  }
-  if (target.startsWith('/')) {
-    target = target.slice(1);
-  }
-  return target.replace(/\\/g, '/');
+
+  addCandidate(target);
+  return candidates;
 }
 
 function listMarkdownFiles(vaultPath: string): string[] {
@@ -93,13 +119,21 @@ function buildKnownIds(vaultPath: string, files: string[]): {
 
 function resolveTarget(
   target: string,
+  sourceId: string,
   known: { ids: Set<string>; idsLower: Map<string, string> },
   entityIndex?: EntityIndex
 ): string | null {
   if (!target) return null;
-  if (known.ids.has(target)) return target;
+
+  for (const candidate of buildLookupCandidates(target, sourceId)) {
+    if (known.ids.has(candidate)) return candidate;
+    const lowerCandidate = candidate.toLowerCase();
+    if (known.idsLower.has(lowerCandidate)) {
+      return known.idsLower.get(lowerCandidate)!;
+    }
+  }
+
   const lower = target.toLowerCase();
-  if (known.idsLower.has(lower)) return known.idsLower.get(lower)!;
   if (entityIndex?.entries.has(lower)) return entityIndex.entries.get(lower)!;
   return null;
 }
@@ -119,13 +153,13 @@ export function scanVaultLinks(
   for (const file of files) {
     const sourceId = toVaultId(vaultPath, file);
     const content = fs.readFileSync(file, 'utf-8');
-    const matches = content.match(WIKI_LINK_REGEX) || [];
+    const matches = extractRawWikiLinks(content);
     linkCount += matches.length;
 
     for (const match of matches) {
       const target = normalizeLinkTarget(match);
       if (!target) continue;
-      const resolved = resolveTarget(target, known, entityIndex);
+      const resolved = resolveTarget(target, sourceId, known, entityIndex);
       if (!resolved) {
         orphans.push({ source: sourceId, target });
         continue;

--- a/src/lib/memory-graph.test.ts
+++ b/src/lib/memory-graph.test.ts
@@ -131,4 +131,89 @@ Linked to [[projects/core-api]] and [[missing-doc]].
       fs.rmSync(vaultPath, { recursive: true, force: true });
     }
   });
+
+  it('parses aliased wiki links with case-insensitive target resolution', async () => {
+    const vaultPath = makeVault();
+    try {
+      writeVaultFile(vaultPath, 'projects/r&d plan.md', '# R&D Plan');
+      writeVaultFile(
+        vaultPath,
+        'notes/research.md',
+        'Roadmap: [[Projects/R&D Plan|FY26 Plan]] and [[projects/r&d plan#Milestones|milestones section]].'
+      );
+
+      const graph = (await buildOrUpdateMemoryGraphIndex(vaultPath)).graph;
+      const sourceId = 'note:notes/research';
+      const wikiEdges = graph.edges.filter((edge) => edge.type === 'wiki_link' && edge.source === sourceId);
+
+      expect(wikiEdges).toHaveLength(1);
+      expect(wikiEdges[0]?.target).toBe('note:projects/r&d plan');
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores wiki links that appear inside markdown code regions', async () => {
+    const vaultPath = makeVault();
+    try {
+      writeVaultFile(vaultPath, 'projects/core-api.md', '# Core API');
+      writeVaultFile(vaultPath, 'projects/inline-code.md', '# Inline Code');
+      writeVaultFile(vaultPath, 'projects/fenced.md', '# Fenced');
+      writeVaultFile(vaultPath, 'projects/indented.md', '# Indented');
+      writeVaultFile(
+        vaultPath,
+        'notes/source.md',
+        [
+          'Real: [[projects/core-api]]',
+          '',
+          'Inline code: `[[projects/inline-code]]`',
+          '',
+          '```md',
+          '[[projects/fenced]]',
+          '```',
+          '',
+          '    [[projects/indented]]'
+        ].join('\n')
+      );
+
+      const graph = (await buildOrUpdateMemoryGraphIndex(vaultPath)).graph;
+      const sourceId = 'note:notes/source';
+      const wikiTargets = graph.edges
+        .filter((edge) => edge.type === 'wiki_link' && edge.source === sourceId)
+        .map((edge) => edge.target)
+        .sort();
+
+      expect(wikiTargets).toEqual(['note:projects/core-api']);
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves subdirectory wiki links relative to the source note', async () => {
+    const vaultPath = makeVault();
+    try {
+      writeVaultFile(vaultPath, 'notes/daily/project-plan.md', '# Local Plan');
+      writeVaultFile(vaultPath, 'notes/shared/retrospective.md', '# Retrospective');
+      writeVaultFile(vaultPath, 'projects/project-plan.md', '# Global Plan');
+      writeVaultFile(
+        vaultPath,
+        'notes/daily/2026-02-28.md',
+        'Links: [[project-plan]] and [[../shared/retrospective|retro]].'
+      );
+
+      const graph = (await buildOrUpdateMemoryGraphIndex(vaultPath)).graph;
+      const sourceId = 'note:notes/daily/2026-02-28';
+      const wikiTargets = new Set(
+        graph.edges
+          .filter((edge) => edge.type === 'wiki_link' && edge.source === sourceId)
+          .map((edge) => edge.target)
+      );
+
+      expect(wikiTargets.has('note:notes/daily/project-plan')).toBe(true);
+      expect(wikiTargets.has('note:notes/shared/retrospective')).toBe(true);
+      expect(wikiTargets.has('note:projects/project-plan')).toBe(false);
+    } finally {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/lib/memory-graph.ts
+++ b/src/lib/memory-graph.ts
@@ -2,10 +2,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 import matter from 'gray-matter';
 import { glob } from 'glob';
+import { extractRawWikiLinks, normalizeWikiLinkTarget } from './wiki-links.js';
 
 export const MEMORY_GRAPH_SCHEMA_VERSION = 1;
 const GRAPH_INDEX_RELATIVE_PATH = path.join('.clawvault', 'graph-index.json');
-const WIKI_LINK_RE = /\[\[([^\]]+)\]\]/g;
 const HASH_TAG_RE = /(^|\s)#([\w-]+)/g;
 const FRONTMATTER_RELATION_FIELDS = [
   'related',
@@ -168,28 +168,6 @@ function getGraphIndexPath(vaultPath: string): string {
   return path.join(vaultPath, GRAPH_INDEX_RELATIVE_PATH);
 }
 
-function normalizeWikiTarget(target: string): string {
-  let value = target.trim();
-  if (!value) return '';
-  const pipeIndex = value.indexOf('|');
-  if (pipeIndex >= 0) {
-    value = value.slice(0, pipeIndex);
-  }
-  const hashIndex = value.indexOf('#');
-  if (hashIndex >= 0) {
-    value = value.slice(0, hashIndex);
-  }
-  value = value
-    .trim()
-    .replace(/\\/g, '/')
-    .replace(/^\.\//, '')
-    .replace(/^\/+/, '');
-  if (value.toLowerCase().endsWith('.md')) {
-    value = value.slice(0, -3);
-  }
-  return value.trim();
-}
-
 function collectTags(frontmatter: Record<string, unknown>, markdownContent: string): string[] {
   const tags = new Set<string>();
   const fmTags = frontmatter.tags;
@@ -216,13 +194,15 @@ function collectTags(frontmatter: Record<string, unknown>, markdownContent: stri
 
 function extractWikiTargets(markdownContent: string): string[] {
   const targets = new Set<string>();
-  for (const match of markdownContent.matchAll(WIKI_LINK_RE)) {
-    const candidate = match[1];
-    if (!candidate) continue;
+  for (const candidate of extractRawWikiLinks(markdownContent)) {
     const normalized = normalizeWikiTarget(candidate);
     if (normalized) targets.add(normalized);
   }
   return [...targets];
+}
+
+function normalizeWikiTarget(target: string): string {
+  return normalizeWikiLinkTarget(target);
 }
 
 function toStringArray(value: unknown): string[] {
@@ -276,16 +256,65 @@ function buildNoteRegistry(relativePaths: string[]): NoteRegistry {
   return { byLowerPath, byLowerBasename };
 }
 
-function resolveTargetNodeId(rawTarget: string, registry: NoteRegistry): string {
+function normalizeLookupPath(candidate: string): string {
+  const normalized = normalizeWikiTarget(candidate);
+  if (!normalized) return '';
+
+  const resolved = path.posix.normalize(normalized).replace(/^\/+/, '');
+  if (!resolved || resolved === '.' || resolved.startsWith('../')) {
+    return '';
+  }
+  return resolved;
+}
+
+function buildTargetLookupCandidates(target: string, sourceNoteKey: string): string[] {
+  const candidates: string[] = [];
+  const sourceDir = path.posix.dirname(sourceNoteKey);
+  const hasSourceDir = sourceDir !== '.';
+  const isRelativeTarget = target.startsWith('./') || target.startsWith('../');
+
+  const addCandidate = (candidate: string): void => {
+    const normalized = normalizeLookupPath(candidate);
+    if (!normalized || candidates.includes(normalized)) return;
+    candidates.push(normalized);
+  };
+
+  if (isRelativeTarget) {
+    if (hasSourceDir) {
+      addCandidate(path.posix.join(sourceDir, target));
+    } else {
+      addCandidate(target);
+    }
+    if (target.startsWith('./')) {
+      addCandidate(target.slice(2));
+    }
+    return candidates;
+  }
+
+  if (!target.includes('/')) {
+    if (hasSourceDir) {
+      addCandidate(`${sourceDir}/${target}`);
+    }
+    addCandidate(target);
+    return candidates;
+  }
+
+  addCandidate(target);
+  return candidates;
+}
+
+function resolveTargetNodeId(rawTarget: string, registry: NoteRegistry, sourceNoteKey: string): string {
   const normalized = normalizeWikiTarget(rawTarget);
   if (!normalized) {
     return toUnresolvedNodeId(rawTarget);
   }
-
   const lowerTarget = normalized.toLowerCase();
-  const direct = registry.byLowerPath.get(lowerTarget);
-  if (direct) {
-    return toNoteNodeId(direct);
+
+  for (const candidate of buildTargetLookupCandidates(normalized, sourceNoteKey)) {
+    const direct = registry.byLowerPath.get(candidate.toLowerCase());
+    if (direct) {
+      return toNoteNodeId(direct);
+    }
   }
 
   if (!normalized.includes('/')) {
@@ -379,7 +408,7 @@ function parseFileFragment(
 
   const wikiTargets = extractWikiTargets(parsed.content);
   for (const target of wikiTargets) {
-    const targetNodeId = resolveTargetNodeId(target, registry);
+    const targetNodeId = resolveTargetNodeId(target, registry, noteKey);
     if (targetNodeId.startsWith('unresolved:') && !nodes.has(targetNodeId)) {
       nodes.set(
         targetNodeId,
@@ -396,7 +425,7 @@ function parseFileFragment(
   }
 
   for (const relation of extractFrontmatterRelations(frontmatter)) {
-    const targetNodeId = resolveTargetNodeId(relation.target, registry);
+    const targetNodeId = resolveTargetNodeId(relation.target, registry, noteKey);
     if (targetNodeId.startsWith('unresolved:') && !nodes.has(targetNodeId)) {
       nodes.set(
         targetNodeId,

--- a/src/lib/wiki-links.ts
+++ b/src/lib/wiki-links.ts
@@ -1,0 +1,161 @@
+import * as path from 'path';
+
+function stripInlineCode(line: string): string {
+  let result = '';
+  let cursor = 0;
+
+  while (cursor < line.length) {
+    if (line[cursor] !== '`') {
+      result += line[cursor];
+      cursor += 1;
+      continue;
+    }
+
+    let fenceLength = 1;
+    while (cursor + fenceLength < line.length && line[cursor + fenceLength] === '`') {
+      fenceLength += 1;
+    }
+
+    const fence = '`'.repeat(fenceLength);
+    const closeIndex = line.indexOf(fence, cursor + fenceLength);
+    if (closeIndex === -1) {
+      result += fence;
+      cursor += fenceLength;
+      continue;
+    }
+
+    cursor = closeIndex + fenceLength;
+  }
+
+  return result;
+}
+
+function parseFence(line: string): { marker: '`' | '~'; length: number } | null {
+  const match = line.match(/^[ \t]{0,3}(`{3,}|~{3,})/);
+  if (!match) return null;
+  const marker = match[1][0];
+  if (marker !== '`' && marker !== '~') return null;
+  return { marker, length: match[1].length };
+}
+
+function isFenceClose(line: string, fence: { marker: '`' | '~'; length: number }): boolean {
+  const re = new RegExp(`^[ \\t]{0,3}${fence.marker}{${fence.length},}[ \\t]*$`);
+  return re.test(line);
+}
+
+/**
+ * Remove markdown code regions from content:
+ * - Fenced code blocks (``` and ~~~)
+ * - Indented code block lines
+ * - Inline code spans (`code`)
+ */
+export function stripMarkdownCode(markdownContent: string): string {
+  const lines = markdownContent.split('\n');
+  const visibleLines: string[] = [];
+  let activeFence: { marker: '`' | '~'; length: number } | null = null;
+
+  for (const line of lines) {
+    if (activeFence) {
+      if (isFenceClose(line, activeFence)) {
+        activeFence = null;
+      }
+      visibleLines.push('');
+      continue;
+    }
+
+    const openingFence = parseFence(line);
+    if (openingFence) {
+      activeFence = openingFence;
+      visibleLines.push('');
+      continue;
+    }
+
+    if (/^(?: {4}|\t)/.test(line)) {
+      visibleLines.push('');
+      continue;
+    }
+
+    visibleLines.push(stripInlineCode(line));
+  }
+
+  return visibleLines.join('\n');
+}
+
+/**
+ * Extract raw wiki-link contents (without surrounding [[ ]]) from markdown.
+ * Ignores links inside markdown code regions.
+ */
+export function extractRawWikiLinks(markdownContent: string): string[] {
+  const content = stripMarkdownCode(markdownContent);
+  const links: string[] = [];
+  let cursor = 0;
+
+  while (cursor < content.length) {
+    const start = content.indexOf('[[', cursor);
+    if (start === -1) break;
+
+    const end = content.indexOf(']]', start + 2);
+    if (end === -1) break;
+
+    const candidate = content.slice(start + 2, end).trim();
+    if (candidate) {
+      links.push(candidate);
+    }
+    cursor = end + 2;
+  }
+
+  return links;
+}
+
+/**
+ * Normalize a wiki-link target into vault-path form.
+ * - Strips alias (|display)
+ * - Strips heading (#section)
+ * - Converts path separators to forward slashes
+ * - Trims path segments and optional .md extension
+ */
+export function normalizeWikiLinkTarget(rawTarget: string): string {
+  let value = rawTarget.trim();
+  if (!value) return '';
+
+  if (value.startsWith('[[') && value.endsWith(']]')) {
+    value = value.slice(2, -2).trim();
+  }
+
+  const pipeIndex = value.indexOf('|');
+  if (pipeIndex >= 0) {
+    value = value.slice(0, pipeIndex);
+  }
+
+  if (value.startsWith('#')) {
+    return '';
+  }
+
+  const hashIndex = value.indexOf('#');
+  if (hashIndex >= 0) {
+    value = value.slice(0, hashIndex);
+  }
+
+  value = value
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '');
+  if (!value) return '';
+
+  value = value
+    .split('/')
+    .map((segment) => segment.trim())
+    .join('/');
+
+  const normalizedPath = path.posix.normalize(value);
+  if (!normalizedPath || normalizedPath === '.') {
+    return '';
+  }
+
+  value = normalizedPath;
+  if (value.toLowerCase().endsWith('.md')) {
+    value = value.slice(0, -3);
+  }
+
+  return value.trim();
+}


### PR DESCRIPTION
Fixes GitHub issue #97 by improving wiki-link parsing and resolution, centralizing logic, and adding comprehensive tests.

The previous parser was overly permissive, leading to incorrect link detection in code blocks and issues with aliases, case sensitivity, and subdirectory resolution. This PR introduces a robust shared utility to address these issues and ensure consistent behavior across graph and backlink systems.

---
<p><a href="https://cursor.com/agents/bc-75ba1a22-15c2-4d59-b90b-aa7b4a58ca4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75ba1a22-15c2-4d59-b90b-aa7b4a58ca4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

